### PR TITLE
Add support for SharedMemory from Python3.8

### DIFF
--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -75,6 +75,10 @@ _CLEANUP_FUNCS = {
 
 if os.name == "posix":
     _CLEANUP_FUNCS['semlock'] = sem_unlink
+    if sys.version_info >= (3, 8):
+        import _posixshmem
+        _CLEANUP_FUNCS['shared_memory'] = _posixshmem.shm_unlink
+
 
 VERBOSE = False
 


### PR DESCRIPTION
`loky.backend.resource_tracker` does not support `multiprocessing.shared_memory` from Python 3.8+.

When `shared_memory` is used, each python process starts its own resource tracker and resource becomes released twice. It happens because `shared_memory` relies on `multiprocessing.resource_tracker`, not loky's.

When I force it to use `loky`:
```python
import os
import sys

if sys.version_info >= (3, 8) and os.name == 'posix':
    from loky.backend import resource_tracker
    sys.modules['multiprocessing.resource_tracker'] = resource_tracker
```
It complies that it doesn't have cleanup function for `shared_memory`, so I added it like in `multiprocessing.resource_tracker`