### PR TITLE
make loky process inherit multiprocessing's resource_tracker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@
 - In Python 3.8, loky processes now inherit multiprocessing's
   ``resource_tracker`` created from their parent. As a consequence, no spurious
   ``resource_tracker`` warnings are emitted when loky workers manipulate
-  ``shared_memory`` objects (#242)
+  ``shared_memory`` objects (#242).
+  Note that loky still needs to use its own resource tracker instance to manage
+  resources that require the reference counting logic such as joblib temporary
+  memory mapped files for now.
 
 - The ``resource_tracker`` now comes with built-in support for tracking files
   in all OSes.  In addition, Python processes can now signal they do not need a
@@ -214,4 +217,3 @@
 - Add support for calling dynamically defined function when cloudpickle is available (#47)
 - Fix resizing of the executor (#51)
 - Various rare race condition fixes
-

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 ### 2.7.0 - XXXX-YY-ZZ
+- In Python 3.8, loky processes now inherit multiprocessing's
+  ``resource_tracker`` created from their parent. As a consequence, no spurious
+  ``resource_tracker`` warnings are emitted when loky workers manipulate
+  ``shared_memory`` objects (#242)
 
 - The ``resource_tracker`` now comes with built-in support for tracking files
   in all OSes.  In addition, Python processes can now signal they do not need a

--- a/loky/backend/popen_loky_posix.py
+++ b/loky/backend/popen_loky_posix.py
@@ -149,6 +149,10 @@ if sys.platform != "win32":
                 reduction._mk_inheritable(child_w)
                 reduction._mk_inheritable(tracker_fd)
                 self._fds.extend([child_r, child_w, tracker_fd])
+                if sys.version_info >= (3, 8) and os.name == 'posix':
+                    mp_tracker_fd = prep_data['mp_tracker_args']['fd']
+                    self.duplicate_for_child(mp_tracker_fd)
+
                 from .fork_exec import fork_exec
                 pid = fork_exec(cmd_python, self._fds, env=process_obj.env)
                 util.debug("launched python with pid {} and cmd:\n{}"

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -75,6 +75,10 @@ _CLEANUP_FUNCS = {
 
 if os.name == "posix":
     _CLEANUP_FUNCS['semlock'] = sem_unlink
+    if sys.version_info >= (3, 8):
+        import _posixshmem
+        _CLEANUP_FUNCS['shared_memory'] = _posixshmem.shm_unlink
+
 
 VERBOSE = False
 

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -75,9 +75,6 @@ _CLEANUP_FUNCS = {
 
 if os.name == "posix":
     _CLEANUP_FUNCS['semlock'] = sem_unlink
-    if sys.version_info >= (3, 8):
-        import _posixshmem
-        _CLEANUP_FUNCS['shared_memory'] = _posixshmem.shm_unlink
 
 
 VERBOSE = False

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -540,10 +540,19 @@ class TestLokyBackend:
             # no other files should be opened at this stage in the process
             assert (is_pipe or is_std or is_rng or is_mem)
 
-        # there should be one pipe for communication with main process
-        # and the semaphore tracker pipe and the Connection pipe
-        assert n_pipe == 3, ("Some pipes were not properly closed during the "
-                             "child process setup.")
+        # there should be:
+        # - one pipe for communication with main process
+        # - loky's resource_tracker pipe
+        # - the Connection pipe
+        # - additionally, on posix + Python 3.8: multiprocessing's
+        #   resource_tracker pipe
+        if sys.version_info >= (3, 8) and os.name == 'posix':
+            n_expected_pipes = 4
+        else:
+            n_expected_pipes = 3
+        msg = ("Some pipes were not properly closed during the child process "
+               "setup.")
+        assert n_pipe == n_expected_pipes, msg
 
         # assert that the writable part of the Pipe (not passed to child),
         # have been properly closed.

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -284,3 +284,43 @@ class TestResourceTracker:
     def test_resource_tracker_sigkill(self):
         # Uncatchable signal.
         self.check_resource_tracker_death(signal.SIGKILL, True)
+
+    @pytest.mark.skipIf(sys.version_info < (3, 8),
+                        "SharedMemory introduced in Python 3.8")
+    def test_loky_process_inherit_multiprocessing_resource_tracker(self):
+        cmd = '''if 1:
+        from loky import get_reusable_executor
+        from multiprocessing.shared_memory import SharedMemory
+        from multiprocessing.resource_tracker import (
+            _resource_tracker as mp_resource_tracker
+        )
+
+        def rtracker_getattrs():
+            from multiprocessing.resource_tracker import (
+                _resource_tracker as mp_resource_tracker
+            )
+            return mp_resource_tracker._fd, mp_resource_tracker._pid
+
+
+        if __name__ == '__main__':
+            executor = get_reusable_executor(max_workers=1)
+            # warm up
+            f = executor.submit(id, 1).result()
+
+            # loky forces the creation of the resource tracker at process
+            # creation so that loky processes can inherit its file descriptor.
+            fd, pid = executor.submit(rtracker_getattrs).result()
+            assert fd == mp_resource_tracker._fd
+            assert pid == mp_resource_tracker._pid
+
+            # non-regression test for #242: unlinking in a loky process a
+            # shared_memory segment tracked by multiprocessing and created its
+            # parent should not generate warnings.
+            shm = SharedMemory(create=True, size=10)
+            f = executor.submit(shm.unlink).result()
+
+        '''
+        p = subprocess.Popen([sys.executable, '-c', cmd],
+                             stderr=subprocess.PIPE,
+                             stdout=subprocess.PIPE)
+        out, err = p.communicate()

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -285,8 +285,8 @@ class TestResourceTracker:
         # Uncatchable signal.
         self.check_resource_tracker_death(signal.SIGKILL, True)
 
-    @pytest.mark.skipIf(sys.version_info < (3, 8),
-                        "SharedMemory introduced in Python 3.8")
+    @pytest.mark.skipif(sys.version_info < (3, 8),
+                        reason="SharedMemory introduced in Python 3.8")
     def test_loky_process_inherit_multiprocessing_resource_tracker(self):
         cmd = '''if 1:
         from loky import get_reusable_executor

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -295,7 +295,7 @@ class TestResourceTracker:
             _resource_tracker as mp_resource_tracker
         )
 
-        def rtracker_getattrs():
+        def mp_rtracker_getattrs():
             from multiprocessing.resource_tracker import (
                 _resource_tracker as mp_resource_tracker
             )
@@ -309,7 +309,7 @@ class TestResourceTracker:
 
             # loky forces the creation of the resource tracker at process
             # creation so that loky processes can inherit its file descriptor.
-            fd, pid = executor.submit(rtracker_getattrs).result()
+            fd, pid = executor.submit(mp_rtracker_getattrs).result()
             assert fd == mp_resource_tracker._fd
             assert pid == mp_resource_tracker._pid
 
@@ -324,3 +324,5 @@ class TestResourceTracker:
                              stderr=subprocess.PIPE,
                              stdout=subprocess.PIPE)
         out, err = p.communicate()
+        assert out.decode() == ""
+        assert err.decode() == ""


### PR DESCRIPTION
Complements (supersedes?) #242 

`loky` processes should inherit `multiprocessing`'s `resource_tracker` so that `register/unregister` requests of `SharedMemory` objects can be successfully executed from them.
Note that in response to https://github.com/joblib/loky/pull/242#issuecomment-620027480: `loky` indeed has to call `ensure_running` before launching its' process.

@arquolo I'm sorry if you already started to work on this. I'd rather have this merged soon because it blocks a whole series of PR (and especially joblib/joblib#966).

cc @tomMoral @ogrisel  