### PR TITLE
stop referencing tomMoral/loky

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,8 +83,8 @@ IDEX Paris-Saclay, ANR-11-IDEX-0003-02
 
 .. |azurepipelines| image:: https://dev.azure.com/joblib/loky/_apis/build/status/joblib.loky?branchName=master
    :target: https://dev.azure.com/joblib/loky/_build?definitionId=2&_a=summary&repositoryFilter=2&branchFilter=38
-.. |codecov| image:: https://codecov.io/gh/tomMoral/loky/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/tomMoral/loky
+.. |codecov| image:: https://codecov.io/gh/joblib/loky/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/joblib/loky
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
                  "concurrent.futures.ProcessPoolExecutor"),
     long_description=open('README.md', 'rb').read().decode('utf-8'),
     long_description_content_type='text/markdown',
-    url='https://github.com/tommoral/loky/',
+    url='https://github.com/joblib/loky/',
     author='Thomas Moreau',
     author_email='thomas.moreau.2010@gmail.com',
     packages=packages,


### PR DESCRIPTION
the `codecov` badge and the `setup.py` `url`, still reference `tomMoral/loky`. We may want to change it and release `2.7.1` as this makes the package look "fishy"/"phony" on PyPI (no stars, no issues, 1 fork)... see https://pypi.org/project/loky/
@tomMoral @ogrisel