### PR TITLE
Increase ReusablePoolExecutor extensiblity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-### 3.0.0 - XXXX-YY-ZZ
+### 2.8.0 - 2020-05-14
 
 - Internal refactoring: add private factory class method to
   ``_ReusablePoolExecutor`` to ease extensibility in joblib (#253).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,7 @@
 ### 3.0.0 - XXXX-YY-ZZ
 
-- Users can now subclass the `_ReusablePoolExecutor` class, and call
-  the classmethod `subclass.get_reusable_executor` to get a reusable instance
-  of this subclass (#253).
+- Internal refactoring: add private factory class method to
+  ``_ReusablePoolExecutor`` to ease extensibility in joblib (#253).
 
 
 ### 2.7.0 - 2020-04-30

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ### 3.0.0 - XXXX-YY-ZZ
 
+- Users can now subclass the `_ReusablePoolExecutor` class, and call
+  the classmethod `subclass.get_reusable_executor` to get a reusable instance
+  of this subclass (#253).
+
 
 ### 2.7.0 - 2020-04-30
 

--- a/loky/reusable_executor.py
+++ b/loky/reusable_executor.py
@@ -123,8 +123,9 @@ class _ReusablePoolExecutor(ProcessPoolExecutor):
             if isinstance(context, STRING_TYPE):
                 context = get_context(context)
             if context is not None and context.get_start_method() == "fork":
-                raise ValueError("Cannot use reusable executor with the 'fork' "
-                                 "context")
+                raise ValueError(
+                    "Cannot use reusable executor with the 'fork' context"
+                )
 
             kwargs = dict(context=context, timeout=timeout,
                           job_reducers=job_reducers,

--- a/loky/reusable_executor.py
+++ b/loky/reusable_executor.py
@@ -81,65 +81,12 @@ def get_reusable_executor(max_workers=None, context=None, timeout=10,
     in the children before any module is loaded. This only works with with the
     ``loky`` context and it is unreliable on Windows with Python < 3.6.
     """
-    with _executor_lock:
-        global _executor, _executor_kwargs
-        executor = _executor
-
-        if max_workers is None:
-            if reuse is True and executor is not None:
-                max_workers = executor._max_workers
-            else:
-                max_workers = cpu_count()
-        elif max_workers <= 0:
-            raise ValueError(
-                "max_workers must be greater than 0, got {}."
-                .format(max_workers))
-
-        if isinstance(context, STRING_TYPE):
-            context = get_context(context)
-        if context is not None and context.get_start_method() == "fork":
-            raise ValueError("Cannot use reusable executor with the 'fork' "
-                             "context")
-
-        kwargs = dict(context=context, timeout=timeout,
-                      job_reducers=job_reducers,
-                      result_reducers=result_reducers,
-                      initializer=initializer, initargs=initargs,
-                      env=env)
-        if executor is None:
-            mp.util.debug("Create a executor with max_workers={}."
-                          .format(max_workers))
-            executor_id = _get_next_executor_id()
-            _executor_kwargs = kwargs
-            _executor = executor = _ReusablePoolExecutor(
-                _executor_lock, max_workers=max_workers,
-                executor_id=executor_id, **kwargs)
-        else:
-            if reuse == 'auto':
-                reuse = kwargs == _executor_kwargs
-            if (executor._flags.broken or executor._flags.shutdown
-                    or not reuse):
-                if executor._flags.broken:
-                    reason = "broken"
-                elif executor._flags.shutdown:
-                    reason = "shutdown"
-                else:
-                    reason = "arguments have changed"
-                mp.util.debug(
-                    "Creating a new executor with max_workers={} as the "
-                    "previous instance cannot be reused ({})."
-                    .format(max_workers, reason))
-                executor.shutdown(wait=True, kill_workers=kill_workers)
-                _executor = executor = _executor_kwargs = None
-                # Recursive call to build a new instance
-                return get_reusable_executor(max_workers=max_workers,
-                                             **kwargs)
-            else:
-                mp.util.debug("Reusing existing executor with max_workers={}."
-                              .format(executor._max_workers))
-                executor._resize(max_workers)
-
-    return executor
+    return _ReusablePoolExecutor.get_current_executor(
+        max_workers=max_workers, context=context, timeout=timeout,
+        kill_workers=kill_workers, reuse=reuse, job_reducers=job_reducers,
+        result_reducers=result_reducers, initializer=initializer,
+        initargs=initargs, env=env
+    )
 
 
 class _ReusablePoolExecutor(ProcessPoolExecutor):
@@ -153,6 +100,73 @@ class _ReusablePoolExecutor(ProcessPoolExecutor):
             initializer=initializer, initargs=initargs, env=env)
         self.executor_id = executor_id
         self._submit_resize_lock = submit_resize_lock
+
+    @classmethod
+    def get_current_executor(cls, max_workers=None, context=None, timeout=10,
+                             kill_workers=False, reuse="auto",
+                             job_reducers=None, result_reducers=None,
+                             initializer=None, initargs=(), env=None):
+        with _executor_lock:
+            global _executor, _executor_kwargs
+            executor = _executor
+
+            if max_workers is None:
+                if reuse is True and executor is not None:
+                    max_workers = executor._max_workers
+                else:
+                    max_workers = cpu_count()
+            elif max_workers <= 0:
+                raise ValueError(
+                    "max_workers must be greater than 0, got {}."
+                    .format(max_workers))
+
+            if isinstance(context, STRING_TYPE):
+                context = get_context(context)
+            if context is not None and context.get_start_method() == "fork":
+                raise ValueError("Cannot use reusable executor with the 'fork' "
+                                 "context")
+
+            kwargs = dict(context=context, timeout=timeout,
+                          job_reducers=job_reducers,
+                          result_reducers=result_reducers,
+                          initializer=initializer, initargs=initargs,
+                          env=env)
+            if executor is None:
+                mp.util.debug("Create a executor with max_workers={}."
+                              .format(max_workers))
+                executor_id = _get_next_executor_id()
+                _executor_kwargs = kwargs
+                _executor = executor = cls(
+                    _executor_lock, max_workers=max_workers,
+                    executor_id=executor_id, **kwargs)
+            else:
+                if reuse == 'auto':
+                    reuse = kwargs == _executor_kwargs
+                if (executor._flags.broken or executor._flags.shutdown
+                        or not reuse):
+                    if executor._flags.broken:
+                        reason = "broken"
+                    elif executor._flags.shutdown:
+                        reason = "shutdown"
+                    else:
+                        reason = "arguments have changed"
+                    mp.util.debug(
+                        "Creating a new executor with max_workers={} as the "
+                        "previous instance cannot be reused ({})."
+                        .format(max_workers, reason))
+                    executor.shutdown(wait=True, kill_workers=kill_workers)
+                    _executor = executor = _executor_kwargs = None
+                    # Recursive call to build a new instance
+                    return cls.get_current_executor(max_workers=max_workers,
+                                                    **kwargs)
+                else:
+                    mp.util.debug(
+                        "Reusing existing executor with max_workers={}."
+                        .format(executor._max_workers)
+                    )
+                    executor._resize(max_workers)
+
+        return executor
 
     def submit(self, fn, *args, **kwargs):
         with self._submit_resize_lock:

--- a/loky/reusable_executor.py
+++ b/loky/reusable_executor.py
@@ -81,12 +81,13 @@ def get_reusable_executor(max_workers=None, context=None, timeout=10,
     in the children before any module is loaded. This only works with with the
     ``loky`` context and it is unreliable on Windows with Python < 3.6.
     """
-    return _ReusablePoolExecutor.get_reusable_executor(
+    _executor, _ = _ReusablePoolExecutor.get_reusable_executor(
         max_workers=max_workers, context=context, timeout=timeout,
         kill_workers=kill_workers, reuse=reuse, job_reducers=job_reducers,
         result_reducers=result_reducers, initializer=initializer,
         initargs=initargs, env=env
     )
+    return _executor
 
 
 class _ReusablePoolExecutor(ProcessPoolExecutor):
@@ -133,6 +134,7 @@ class _ReusablePoolExecutor(ProcessPoolExecutor):
                           initializer=initializer, initargs=initargs,
                           env=env)
             if executor is None:
+                is_reused = False
                 mp.util.debug("Create a executor with max_workers={}."
                               .format(max_workers))
                 executor_id = _get_next_executor_id()
@@ -165,9 +167,10 @@ class _ReusablePoolExecutor(ProcessPoolExecutor):
                         "Reusing existing executor with max_workers={}."
                         .format(executor._max_workers)
                     )
+                    is_reused = True
                     executor._resize(max_workers)
 
-        return executor
+        return executor, is_reused
 
     def submit(self, fn, *args, **kwargs):
         with self._submit_resize_lock:

--- a/loky/reusable_executor.py
+++ b/loky/reusable_executor.py
@@ -81,7 +81,7 @@ def get_reusable_executor(max_workers=None, context=None, timeout=10,
     in the children before any module is loaded. This only works with with the
     ``loky`` context and it is unreliable on Windows with Python < 3.6.
     """
-    return _ReusablePoolExecutor.get_current_executor(
+    return _ReusablePoolExecutor.get_reusable_executor(
         max_workers=max_workers, context=context, timeout=timeout,
         kill_workers=kill_workers, reuse=reuse, job_reducers=job_reducers,
         result_reducers=result_reducers, initializer=initializer,
@@ -102,10 +102,10 @@ class _ReusablePoolExecutor(ProcessPoolExecutor):
         self._submit_resize_lock = submit_resize_lock
 
     @classmethod
-    def get_current_executor(cls, max_workers=None, context=None, timeout=10,
-                             kill_workers=False, reuse="auto",
-                             job_reducers=None, result_reducers=None,
-                             initializer=None, initargs=(), env=None):
+    def get_reusable_executor(cls, max_workers=None, context=None, timeout=10,
+                              kill_workers=False, reuse="auto",
+                              job_reducers=None, result_reducers=None,
+                              initializer=None, initargs=(), env=None):
         with _executor_lock:
             global _executor, _executor_kwargs
             executor = _executor
@@ -158,8 +158,8 @@ class _ReusablePoolExecutor(ProcessPoolExecutor):
                     executor.shutdown(wait=True, kill_workers=kill_workers)
                     _executor = executor = _executor_kwargs = None
                     # Recursive call to build a new instance
-                    return cls.get_current_executor(max_workers=max_workers,
-                                                    **kwargs)
+                    return cls.get_reusable_executor(max_workers=max_workers,
+                                                     **kwargs)
                 else:
                     mp.util.debug(
                         "Reusing existing executor with max_workers={}."


### PR DESCRIPTION
the `get_reusable_executor` function call makes it difficult for third party libraries (like `joblib`) to subclass the (admittedly private) `_ReusablePoolExecutor` class. I propose to change this by making `get_reusable_executor` wrap a `classmethod` and thus stop hardcoding a `_ReusablePoolExecutor` constructor  inside it.