### PR TITLE
Worker ID functionality

### DIFF
--- a/loky/__init__.py
+++ b/loky/__init__.py
@@ -13,13 +13,14 @@ from .backend.reduction import set_loky_pickler
 from .reusable_executor import get_reusable_executor
 from .cloudpickle_wrapper import wrap_non_picklable_objects
 from .process_executor import BrokenProcessPool, ProcessPoolExecutor
+from .worker_id import get_worker_id
 
 
 __all__ = ["get_reusable_executor", "cpu_count", "wait", "as_completed",
            "Future", "Executor", "ProcessPoolExecutor",
            "BrokenProcessPool", "CancelledError", "TimeoutError",
            "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED",
-           "wrap_non_picklable_objects", "set_loky_pickler"]
+           "wrap_non_picklable_objects", "set_loky_pickler", "get_worker_id"]
 
 
 __version__ = '3.0.0.dev0'

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -1099,11 +1099,9 @@ class ProcessPoolExecutor(_base.Executor):
                 # Try to spawn the process with some environment variable to
                 # overwrite but it only works with the loky context for now.
                 env = self._env
-                print("env:", env)
                 if _CURRENT_DEPTH == 0 and self._env is not None:
                     env = self._env.copy()
                     env['LOKY_WORKER_ID'] = str(worker_id)
-                    print("!!", env['LOKY_WORKER_ID'])
                 p = self._context.Process(target=_process_worker, args=args,
                                           env=env)
             except TypeError:

--- a/loky/worker_id.py
+++ b/loky/worker_id.py
@@ -1,0 +1,8 @@
+import os
+
+
+def get_worker_id():
+    wid = os.environ.get('LOKY_WORKER_ID', None)
+    if wid is None:
+        return -1
+    return int(wid)

--- a/tests/test_worker_id.py
+++ b/tests/test_worker_id.py
@@ -1,0 +1,31 @@
+import os
+import time
+import pytest
+import numpy as np
+from collections import defaultdict
+from loky import get_reusable_executor, get_worker_id
+
+
+def random_sleep(k):
+    rng = np.random.RandomState(seed=k)
+    duration = rng.uniform(0, 0.05)
+    t0 = time.time()
+    time.sleep(duration)
+    t1 = time.time()
+    wid = get_worker_id()
+    return (wid, t0, t1)
+
+
+def test_worker_ids():
+    """Test that worker IDs are always unique, with re-use over time"""
+    executor = get_reusable_executor(max_workers=4, timeout=2)
+    results = executor.map(random_sleep, range(100))
+
+    all_intervals = defaultdict(list)
+    for wid, t0, t1 in results:
+        all_intervals[wid].append((t0, t1))
+
+    for intervals in all_intervals.values():
+        intervals = sorted(intervals)
+        for i in range(len(intervals) - 1):
+            assert intervals[i + 1][0] >= intervals[i][1]


### PR DESCRIPTION
Hello loky team.

I would like to implement a "worker ID" function for loky. I originally wrote an [issue](https://github.com/joblib/joblib/issues/1008) and a [pull request](https://github.com/joblib/joblib/pull/1009) on the joblib github page. @tomMoral has kindly pointed me to the correct place for this PR.

@tomMoral: I have stripped this PR down so that it is relevant to loky and added a unit test. The worker ID assignment now accounts for available IDs with the `process_worker_id` variable. I'm not sure if I have accounted for all mechanisms by which processes can be ended though.