### PR TITLE
FIX safe queue compat for python3.9

### DIFF
--- a/loky/backend/queues.py
+++ b/loky/backend/queues.py
@@ -72,7 +72,10 @@ class Queue(mp_Queue):
         (self._ignore_epipe, self._maxsize, self._reader, self._writer,
          self._reducers, self._rlock, self._wlock, self._sem,
          self._opid) = state
-        self._after_fork()
+        if sys.version_info >= (3, 9):
+            self._reset()
+        else:
+            self._after_fork()
 
     # Overload _start_thread to correctly call our custom _feed
     def _start_thread(self):

--- a/loky/backend/queues.py
+++ b/loky/backend/queues.py
@@ -54,7 +54,10 @@ class Queue(mp_Queue):
             # For use by concurrent.futures
             self._ignore_epipe = False
 
-            self._after_fork()
+            if sys.version_info >= (3, 9):
+                self._reset()
+            else:
+                self._after_fork()
 
             if sys.platform != 'win32':
                 util.register_after_fork(self, Queue._after_fork)


### PR DESCRIPTION
Fix for #251 .

The change was on the `after_fork/reset` functionality.

```diff
$ git diff 3.8 3.9 -- Lib/multiprocessing/queues.py
diff --git a/Lib/multiprocessing/queues.py b/Lib/multiprocessing/queues.py
index d112db2cd9..a290181487 100644
--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -14,6 +14,7 @@ import os
 import threading
 import collections
 import time
+import types
 import weakref
 import errno
 
@@ -48,8 +49,7 @@ class Queue(object):
         self._sem = ctx.BoundedSemaphore(maxsize)
         # For use by concurrent.futures
         self._ignore_epipe = False
-
-        self._after_fork()
+        self._reset()
 
         if sys.platform != 'win32':
             register_after_fork(self, Queue._after_fork)
@@ -62,11 +62,17 @@ class Queue(object):
     def __setstate__(self, state):
         (self._ignore_epipe, self._maxsize, self._reader, self._writer,
          self._rlock, self._wlock, self._sem, self._opid) = state
-        self._after_fork()
+        self._reset()
 
     def _after_fork(self):
         debug('Queue._after_fork()')
-        self._notempty = threading.Condition(threading.Lock())
+        self._reset(after_fork=True)
+
+    def _reset(self, after_fork=False):
+        if after_fork:
+            self._notempty._at_fork_reinit()
+        else:
+            self._notempty = threading.Condition(threading.Lock())
         self._buffer = collections.deque()
         self._thread = None
         self._jointhread = None
```