### PR TITLE
Add option to count only physical cores in cpu_count

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 - Fix support for Python 3.9 and test against python-nightly from now on
   (#250).
 
+- Add a parameter to ``cpu_count``, ``only_physical_cores``, to return the
+  number of physical cores instead of the number of logical cores (#271).
+
 ### 2.7.0 - 2020-04-30
 
 - Increase the residual memory increase threshold  (100MB -> 300MB) used by

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -192,8 +192,7 @@ def count_physical():
     try:
         if sys.platform == "linux":
             cpu_info = subprocess.run(
-                "lscpu --parse=core".split(" "),
-                capture_output=True)
+                "lscpu --parse=core".split(" "), capture_output=True)
             cpu_info = cpu_info.stdout.decode("utf-8").splitlines()
             cpu_info = {line for line in cpu_info if not line.startswith("#")}
             cpu_count_physical = len(cpu_info)
@@ -206,8 +205,8 @@ def count_physical():
                         if (l and l != "Node,NumberOfCores")]
             cpu_count_physical = sum(map(int, cpu_info))
         elif sys.platform == "darwin":
-            cpu_info = subprocess.run("sysctl -n hw.physicalcpu".split(" "),
-                                      capture_output=True)
+            cpu_info = subprocess.run(
+                "sysctl -n hw.physicalcpu".split(" "), capture_output=True)
             cpu_info = cpu_info.stdout.decode('utf-8')
             cpu_count_physical = int(cpu_info)
         else:

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -130,6 +130,7 @@ def cpu_count(only_physical_cores=False):
     """
     import math
 
+    # TODO: us os.cpu_count when dropping python 2 support
     try:
         cpu_count_mp = mp.cpu_count()
     except NotImplementedError:

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -154,7 +154,8 @@ def cpu_count(only_physical_cores=False):
                     "of cores you want to use.\n")
                 if isinstance(error, str):
                     print(error)
-                else:
+                elif sys.version_info >= (3, 5):
+                    # TODO remove the version check when dropping py2 support
                     traceback.print_tb(error.__traceback__)
 
             cpu_count = max(aggregate_cpu_count, 1)

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -243,7 +243,7 @@ def _count_physical_cores():
         # if cpu_count_physical < 1, we did not find a valid value
         if cpu_count_physical != "not found" and cpu_count_physical < 1:
             cpu_count_physical = "not found"
-            error_message = "found a number of physical cores < 1"
+            error = "found a number of physical cores < 1"
         
     except Exception as e:
         error = e

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -129,8 +129,6 @@ def cpu_count(only_physical_cores=False):
  
     It is also always larger or equal to 1.
     """
-    import math
-
     # TODO: use os.cpu_count when dropping python 2 support
     try:
         cpu_count_mp = mp.cpu_count()
@@ -170,6 +168,8 @@ def cpu_count(only_physical_cores=False):
 
 def _cpu_count_user(cpu_count_mp):
     """Number of user defined available CPUs"""
+    import math
+
     # Number of available CPUs given affinity settings
     cpu_count_affinity = cpu_count_mp
     if hasattr(os, 'sched_getaffinity'):

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -26,7 +26,7 @@ _DEFAULT_START_METHOD = None
 
 # Cache for the number of physical cores to avoid repeating subprocess calls.
 # It should not change during the lifetime of the program.
-physical_cores_cache = None
+physical_cores_cache = [None, '']
 
 if sys.version_info[:2] >= (3, 4):
     from multiprocessing import get_context as mp_get_context
@@ -194,9 +194,9 @@ def _count_physical_cores():
     error_message = ""
 
     # First check if the value is cached
-    global physical_cores_cache
-    if physical_cores_cache is not None:
-        return physical_cores_cache, error_message
+    cpu_count_physical, error_message = physical_cores_cache
+    if cpu_count_physical is not None:
+        return cpu_count_physical, error_message
 
     # Not cached yet
     try:
@@ -231,7 +231,8 @@ def _count_physical_cores():
         cpu_count_physical = "not found"
 
     # Put the result in cache
-    physical_cores_cache = cpu_count_physical
+    physical_cores_cache[0] = cpu_count_physical
+    physical_cores_cache[1] = error_message
     
     return cpu_count_physical, error_message
 

--- a/tests/test_loky_module.py
+++ b/tests/test_loky_module.py
@@ -114,6 +114,10 @@ def test_only_physical_cores_error():
             old_path = os.environ['PATH']
             os.environ['PATH'] = tmp_dir + ":" + old_path
 
+            # clear the cache otherwise the warning is not triggered
+            import loky.backend.context
+            loky.backend.context.physical_cores_cache = None
+
             with pytest.warns(UserWarning, match="Could not find the number of"
                                                  " physical cores"):
                 cpu_count(only_physical_cores=True)

--- a/tests/test_loky_module.py
+++ b/tests/test_loky_module.py
@@ -1,12 +1,16 @@
+import multiprocessing as mp
 import os
 import sys
 import shutil
+import tempfile
 from subprocess import check_output
+import subprocess
 
 import pytest
 
 import loky
 from loky import cpu_count
+from loky.backend.context import _cpu_count_user
 
 
 def test_version():
@@ -19,6 +23,11 @@ def test_cpu_count():
     assert type(cpus) is int
     assert cpus >= 1
 
+    cpus_physical = cpu_count(only_physical_cores=True)
+    assert type(cpus_physical) is int
+    assert 1 <= cpus_physical <= cpus
+
+    # again to check that it's correctly cached
     cpus_physical = cpu_count(only_physical_cores=True)
     assert type(cpus_physical) is int
     assert 1 <= cpus_physical <= cpus
@@ -76,3 +85,54 @@ def test_cpu_count_cfs_limit():
                         'python', '-c', cpu_count_cmd.format(args='')])
 
     assert res.strip().decode('utf-8') == '1'
+
+
+def test_only_physical_cores_error():
+    # Check the warning issued by cpu_count(only_physical_cores=True) when
+    # unable to retrieve the number of physical cores.
+    if sys.platform != "linux":
+        pytest.skip()
+    
+    # if number of available cpus is already restricted, cpu_count will return
+    # that value and no warning is issued even if only_physical_cores == True.
+    # (tested in another test: test_only_physical_cores_with_user_limitation
+    cpu_count_mp = mp.cpu_count()
+    if _cpu_count_user(cpu_count_mp) < cpu_count_mp:
+        pytest.skip()
+
+    start_dir = os.path.abspath('.')
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Write bad lscpu program
+        lscpu_path = tmp_dir + '/lscpu'
+        with open(lscpu_path, 'w') as f:
+            f.write("#!/bin/sh\n"
+                    "exit(1)")
+        os.chmod(lscpu_path, 0o777)
+
+        try:
+            old_path = os.environ['PATH']
+            os.environ['PATH'] = tmp_dir + ":" + old_path
+
+            with pytest.warns(UserWarning, match="Could not find the number of"
+                                                 " physical cores"):
+                cpu_count(only_physical_cores=True)
+
+            # Should only warn the first time
+            with pytest.warns(None) as record:
+                cpu_count(only_physical_cores=True)
+                assert not record
+
+        finally:
+            os.environ['PATH'] = old_path
+
+
+def test_only_physical_cores_with_user_limitation():
+    # Check that user limitation for the available number of cores is
+    # respected even if only_physical_cores == True
+    cpu_count_mp = mp.cpu_count()
+    cpu_count_user = _cpu_count_user(cpu_count_mp)
+
+    if cpu_count_user < cpu_count_mp:
+        assert cpu_count() == cpu_count_user
+        assert cpu_count(only_physical_cores=True) == cpu_count_user

--- a/tests/test_loky_module.py
+++ b/tests/test_loky_module.py
@@ -19,9 +19,13 @@ def test_cpu_count():
     assert type(cpus) is int
     assert cpus >= 1
 
+    cpus_physical = cpu_count(maybe_physical_only=True)
+    assert type(cpus_physical) is int
+    assert 1 <= cpus_physical <= cpus
+
 
 cpu_count_cmd = ("from loky.backend.context import cpu_count;"
-                 "print(cpu_count())")
+                 "print(cpu_count({}))")
 
 
 def test_cpu_count_affinity():
@@ -40,9 +44,14 @@ def test_cpu_count_affinity():
         pytest.skip()
 
     res = check_output([taskset_bin, '-c', '0',
-                        python_bin, '-c', cpu_count_cmd])
+                        python_bin, '-c', cpu_count_cmd.format("")])
+    
+    res_physical = check_output([
+        taskset_bin, '-c', '0', python_bin, '-c',
+        cpu_count_cmd.format(maybe_physical_only=True)])
 
     assert res.strip().decode('utf-8') == '1'
+    assert res_physical.strip().decode('utf-8') == '1'
 
 
 def test_cpu_count_cfs_limit():
@@ -64,6 +73,6 @@ def test_cpu_count_cfs_limit():
     res = check_output([docker_bin, 'run', '--rm', '--cpus', '0.5',
                         '-v', '%s:/loky' % loky_path,
                         'python:3.6',
-                        'python', '-c', cpu_count_cmd])
+                        'python', '-c', cpu_count_cmd.format("")])
 
     assert res.strip().decode('utf-8') == '1'

--- a/tests/test_loky_module.py
+++ b/tests/test_loky_module.py
@@ -122,7 +122,7 @@ def test_only_physical_cores_error():
                                                  " physical cores"):
                 cpu_count(only_physical_cores=True)
 
-            # Should only warn the first time
+            # Should not warn the second time
             with pytest.warns(None) as record:
                 cpu_count(only_physical_cores=True)
                 assert not record

--- a/tests/test_loky_module.py
+++ b/tests/test_loky_module.py
@@ -25,7 +25,7 @@ def test_cpu_count():
 
 
 cpu_count_cmd = ("from loky.backend.context import cpu_count;"
-                 "print(cpu_count({}))")
+                 "print(cpu_count({args}))")
 
 
 def test_cpu_count_affinity():
@@ -44,11 +44,11 @@ def test_cpu_count_affinity():
         pytest.skip()
 
     res = check_output([taskset_bin, '-c', '0',
-                        python_bin, '-c', cpu_count_cmd.format('')])
+                        python_bin, '-c', cpu_count_cmd.format(args='')])
     
     res_physical = check_output([
         taskset_bin, '-c', '0', python_bin, '-c',
-        cpu_count_cmd.format('only_physical_cores=True')])
+        cpu_count_cmd.format(args='only_physical_cores=True')])
 
     assert res.strip().decode('utf-8') == '1'
     assert res_physical.strip().decode('utf-8') == '1'
@@ -73,6 +73,6 @@ def test_cpu_count_cfs_limit():
     res = check_output([docker_bin, 'run', '--rm', '--cpus', '0.5',
                         '-v', '%s:/loky' % loky_path,
                         'python:3.6',
-                        'python', '-c', cpu_count_cmd.format('')])
+                        'python', '-c', cpu_count_cmd.format(args='')])
 
     assert res.strip().decode('utf-8') == '1'

--- a/tests/test_loky_module.py
+++ b/tests/test_loky_module.py
@@ -44,11 +44,11 @@ def test_cpu_count_affinity():
         pytest.skip()
 
     res = check_output([taskset_bin, '-c', '0',
-                        python_bin, '-c', cpu_count_cmd.format("")])
+                        python_bin, '-c', cpu_count_cmd.format('')])
     
     res_physical = check_output([
         taskset_bin, '-c', '0', python_bin, '-c',
-        cpu_count_cmd.format(maybe_physical_only=True)])
+        cpu_count_cmd.format('maybe_physical_only=True')])
 
     assert res.strip().decode('utf-8') == '1'
     assert res_physical.strip().decode('utf-8') == '1'
@@ -73,6 +73,6 @@ def test_cpu_count_cfs_limit():
     res = check_output([docker_bin, 'run', '--rm', '--cpus', '0.5',
                         '-v', '%s:/loky' % loky_path,
                         'python:3.6',
-                        'python', '-c', cpu_count_cmd.format("")])
+                        'python', '-c', cpu_count_cmd.format('')])
 
     assert res.strip().decode('utf-8') == '1'

--- a/tests/test_loky_module.py
+++ b/tests/test_loky_module.py
@@ -19,7 +19,7 @@ def test_cpu_count():
     assert type(cpus) is int
     assert cpus >= 1
 
-    cpus_physical = cpu_count(maybe_physical_only=True)
+    cpus_physical = cpu_count(only_physical_cores=True)
     assert type(cpus_physical) is int
     assert 1 <= cpus_physical <= cpus
 
@@ -48,7 +48,7 @@ def test_cpu_count_affinity():
     
     res_physical = check_output([
         taskset_bin, '-c', '0', python_bin, '-c',
-        cpu_count_cmd.format('maybe_physical_only=True')])
+        cpu_count_cmd.format('only_physical_cores=True')])
 
     assert res.strip().decode('utf-8') == '1'
     assert res_physical.strip().decode('utf-8') == '1'


### PR DESCRIPTION
Fixes #223 

adds a parameter to cpu_count: `maybe_physical_only`. When True it will return the number of physical cores instead of the number of logical cpus unless the number of available cpus is modified in which case we respect it (hence the "maybe" in the param name).

It's not as complete as `psutil.cpu_count(logical=False)` but it does not require compiled code.
Since it makes subprocess calls, the result is cached for efficiency.