### PR TITLE
FIX load libc correctly in test_reusable_executor

### DIFF
--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -32,7 +32,7 @@ if sys.platform == "win32":
 else:
     from signal import SIGKILL
     from ctypes.util import find_library
-    libc = ctypes.CDLL(find_library("libc"))
+    libc = ctypes.CDLL(find_library("c"))
 
 
 try:


### PR DESCRIPTION
Fix test_reusable_executor to load libc via "c" library rather than
"libc".  The latter is incorrect, and does not work in the newest
versions of Python anymore, see https://bugs.python.org/issue42580.