### PR TITLE
Update popen_loky_win32.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ### 3.0.0 - XXXX-YY-ZZ
 
+- Avoid a NameError when calling the `exit` builtin on Windows when
+  loky is executed as part of a frozen Python binary. (#290)
+
 ### 2.9.0 - 2020-10-02
 
 - Fix a side-effect bug in the registration of custom reducers the loky

--- a/loky/backend/popen_loky_win32.py
+++ b/loky/backend/popen_loky_win32.py
@@ -170,4 +170,4 @@ def main():
     from_parent.close()
 
     exitcode = self._bootstrap()
-    exit(exitcode)
+    sys.exit(exitcode)


### PR DESCRIPTION
Hi,

This is a minimal PR that changes the `main` method of the `win32` backend. 

I’ve noticed that an app packaged using [Briefcase](https://github.com/beeware/briefcase) was throwing a `NameError: name ‘exit’ is not defined` when finishing up a process that was started using `joblib`. I am guessing this is because `exit` is not in the global scope when running in frozen environment. This PR simply changes the `exit(exitcode)` to `sys.exit(exitcode)` method instead. 
I’ve had a look at the `posix` backend and it uses `sys.exit(exitcode)` as well.
