### PR TITLE
Fix no attribute import_module for python 3.10

### DIFF
--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -1,15 +1,18 @@
 from __future__ import print_function
 try:
-    import test.support
+    try:
+        from test.support.import_helper import import_module
+    except ImportError:
+        from test.support import import_module
 
     # Skip tests if _multiprocessing wasn't built.
-    test.support.import_module('_multiprocessing')
+    import_module('_multiprocessing')
     # Skip tests if sem_open implementation is broken.
-    test.support.import_module('multiprocessing.synchronize')
+    import_module('multiprocessing.synchronize')
     # import threading after _multiprocessing to raise a more revelant error
     # message: "No module named _multiprocessing" if multiprocessing is not
     # compiled without thread support.
-    test.support.import_module('threading')
+    import_module('threading')
 except ImportError:
     pass
 


### PR DESCRIPTION
Tests fail on Python 3.10 with the following error:
```
tests/_test_process_executor.py:6: in <module>
    test.support.import_module('_multiprocessing')
E   AttributeError: module 'test.support' has no attribute 'import_module'
```
In python 3.10, the `import_module` has moved from the `test.support` module to `test.support.import_helper`.
As fix, try to import the from the new place and if unknown try from the old place.