### PR TITLE
Make _resource_unlink more informative in case of failure

### DIFF
--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -21,7 +21,8 @@ def _resource_unlink(name, rtype):
         resource_tracker._CLEANUP_FUNCS[rtype](name)
     except FileNotFoundError as e:
         new_e = FileNotFoundError(
-            f"Could not find resource of type '{rtype}' with name '{name}'"
+            "Could not find resource of type '{rtype}' with name '{name}'"
+            .format(**locals())
         )
         new_e.errno = e.errno
         raise new_e from e

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -132,10 +132,15 @@ class TestResourceTracker:
                              env=env)
         name1 = p.stdout.readline().rstrip().decode('ascii')
         name2 = p.stdout.readline().rstrip().decode('ascii')
-        error = p.stderr.read().decode("ascii")
+        error = p.stderr.read().decode("ascii").strip()
         if len(error) > 0:
-            print(error)
-            raise RuntimeError(error)
+            expected_warning_msg = (
+                "UserWarning: resource_tracker: There appear to be 2 leaked "
+                "semlock objects to clean up at shutdown"
+            )
+            if error != expected_warning_msg:
+                print(error)
+                raise RuntimeError(error)
 
         # subprocess holding a reference to lock1 is still alive, so this call
         # should succeed

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -25,7 +25,8 @@ def _resource_unlink(name, rtype):
             .format(**locals())
         )
         new_e.errno = e.errno
-        raise new_e from e
+        new_e.__cause__ = e
+        raise new_e
 
 
 def get_rtracker_pid():

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -132,15 +132,6 @@ class TestResourceTracker:
                              env=env)
         name1 = p.stdout.readline().rstrip().decode('ascii')
         name2 = p.stdout.readline().rstrip().decode('ascii')
-        error = p.stderr.read().decode("ascii").strip()
-        if len(error) > 0:
-            expected_warning_msg = (
-                "UserWarning: resource_tracker: There appear to be 2 leaked "
-                "{rtype} objects to clean up at shutdown".format(**locals())
-            )
-            if error != expected_warning_msg:
-                print(error)
-                raise RuntimeError(error)
 
         # subprocess holding a reference to lock1 is still alive, so this call
         # should succeed

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -1,14 +1,12 @@
 """Tests for the ResourceTracker class"""
 import errno
 import gc
-import io
 import os
 import pytest
 import re
 import signal
 import subprocess
 import sys
-import tempfile
 import time
 import warnings
 import weakref
@@ -19,7 +17,14 @@ from loky.backend.context import get_context
 
 
 def _resource_unlink(name, rtype):
-    resource_tracker._CLEANUP_FUNCS[rtype](name)
+    try:
+        resource_tracker._CLEANUP_FUNCS[rtype](name)
+    except FileNotFoundError as e:
+        new_e = FileNotFoundError(
+            f"Could not find resource of type '{rtype}' with name '{name}'"
+        )
+        new_e.errno = e.errno
+        raise new_e from e
 
 
 def get_rtracker_pid():

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -132,6 +132,10 @@ class TestResourceTracker:
                              env=env)
         name1 = p.stdout.readline().rstrip().decode('ascii')
         name2 = p.stdout.readline().rstrip().decode('ascii')
+        error = p.stderr.read().decode("ascii")
+        if len(error) > 0:
+            print(error)
+            raise RuntimeError(error)
 
         # subprocess holding a reference to lock1 is still alive, so this call
         # should succeed

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -136,7 +136,7 @@ class TestResourceTracker:
         if len(error) > 0:
             expected_warning_msg = (
                 "UserWarning: resource_tracker: There appear to be 2 leaked "
-                "semlock objects to clean up at shutdown"
+                "{rtype} objects to clean up at shutdown".format(**locals())
             )
             if error != expected_warning_msg:
                 print(error)


### PR DESCRIPTION
I have some test failing on macOS 11.5.1 locally. Let's see we can reproduce those on the CI with a more informative error message.