### PR TITLE
Initialize viztracer in worker processes

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -45,6 +45,10 @@ jobs:
         imageName: "ubuntu-20.04"
         python.version: "3.5"
         tox.env: py35
+      linux-py27:
+        imageName: "ubuntu-20.04"
+        python.version: "2.7"
+        tox.env: py27
 
   pool:
     vmImage: $(imageName)

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -3,14 +3,10 @@ jobs:
   strategy:
     matrix:
 
-      windows-py38:
+      windows-py39:
         imageName: "vs2017-win2016"
-        python.version: "3.8"
-        tox.env: py38
-      windows-py35:
-        imageName: "vs2017-win2016"
-        python.version: "3.5"
-        tox.env: py35
+        python.version: "3.9"
+        tox.env: py39
       windows-py27:
         imageName: "vs2017-win2016"
         python.version: "2.7"
@@ -20,15 +16,10 @@ jobs:
         imageName: "macos-10.14"
         python.version: "3.8"
         tox.env: py38
-      macos-py35:
+      macos-py36:
         imageName: "macos-10.14"
-        python.version: "3.5"
-        tox.env: py35
-      macos-py27-high-memory:
-        imageName: "macos-10.14"
-        python.version: "2.7"
-        tox.env: py27
-        RUN_MEMORY: "true"
+        python.version: "3.6"
+        tox.env: py36
 
       linux-pypy3:
         imageName: "ubuntu-20.04"
@@ -40,36 +31,20 @@ jobs:
         imageName: "ubuntu-20.04"
         python.version: "3.10"
         tox.env: py310
-      linux-python-py39:
+      linux-python-py39-high-memory:
         imageName: "ubuntu-20.04"
         python.version: "3.9"
         tox.env: py39
-      linux-py38-joblib-tests:
-        imageName: "ubuntu-20.04"
-        python.version: "3.8"
-        tox.env: "py38"
-        joblib.tests: "true"
-      linux-py38-high-memory:
-        imageName: "ubuntu-20.04"
-        python.version: "3.8"
-        tox.env: py38
         RUN_MEMORY: "true"
-      linux-py37:
+      linux-py39-joblib-tests:
         imageName: "ubuntu-20.04"
-        python.version: "3.7"
-        tox.env: py37
-      linux-py36:
-        imageName: "ubuntu-20.04"
-        python.version: "3.6"
-        tox.env: py36
+        python.version: "3.9"
+        tox.env: "py39"
+        joblib.tests: "true"
       linux-py35:
         imageName: "ubuntu-20.04"
         python.version: "3.5"
         tox.env: py35
-      linux-py27:
-        imageName: "ubuntu-20.04"
-        python.version: "2.7"
-        tox.env: py27
 
   pool:
     vmImage: $(imageName)

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -38,6 +38,10 @@ jobs:
 
       linux-python-nightly:
         imageName: "ubuntu-20.04"
+        python.version: "3.10"
+        tox.env: py310
+      linux-python-py39:
+        imageName: "ubuntu-20.04"
         python.version: "3.9"
         tox.env: py39
       linux-py38-joblib-tests:
@@ -77,15 +81,15 @@ jobs:
       inputs:
         versionSpec: '$(python.version)'
       displayName: 'Use Python $(python.version)'
-      condition: ne(variables['python.version'], '3.9')
+      condition: ne(variables['python.version'], '3.10')
     - bash: |
         sudo add-apt-repository ppa:deadsnakes/nightly
         sudo apt update
-        sudo apt install python3.9 python3.9-venv python3.9-dev
-        python3.9 -m venv nightly-venv
+        sudo apt install python3.10 python3.10-venv python3.10-dev
+        python3.10 -m venv nightly-venv
         echo "##vso[task.prependpath]nightly-venv/bin"
-      displayName: Install Python 3.9 from ppa:deadsnakes/nightly
-      condition: eq(variables['python.version'], '3.9')
+      displayName: Install Python 3.10 from ppa:deadsnakes/nightly
+      condition: eq(variables['python.version'], '3.10')
     # azure-pipelines unpredictably switches between Git\bin\bash and
     # Git\usr\bin\bash when running a bash script inside Windows environments.
     # The latter may use wrong bash commands, resulting in errors when codecov

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -31,39 +31,39 @@ jobs:
         RUN_MEMORY: "true"
 
       linux-pypy3:
-        imageName: "ubuntu-16.04"
+        imageName: "ubuntu-20.04"
         python.version: "pypy3"
         tox.env: pypy3
         LOKY_MAX_CPU_COUNT: "2"
 
       linux-python-nightly:
-        imageName: "ubuntu-16.04"
+        imageName: "ubuntu-20.04"
         python.version: "3.9"
         tox.env: py39
       linux-py38-joblib-tests:
-        imageName: "ubuntu-16.04"
+        imageName: "ubuntu-20.04"
         python.version: "3.8"
         tox.env: "py38"
         joblib.tests: "true"
       linux-py38-high-memory:
-        imageName: "ubuntu-16.04"
+        imageName: "ubuntu-20.04"
         python.version: "3.8"
         tox.env: py38
         RUN_MEMORY: "true"
       linux-py37:
-        imageName: "ubuntu-16.04"
+        imageName: "ubuntu-20.04"
         python.version: "3.7"
         tox.env: py37
       linux-py36:
-        imageName: "ubuntu-16.04"
+        imageName: "ubuntu-20.04"
         python.version: "3.6"
         tox.env: py36
       linux-py35:
-        imageName: "ubuntu-16.04"
+        imageName: "ubuntu-20.04"
         python.version: "3.5"
         tox.env: py35
       linux-py27:
-        imageName: "ubuntu-16.04"
+        imageName: "ubuntu-20.04"
         python.version: "2.7"
         tox.env: py27
 

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -7,19 +7,23 @@ jobs:
         imageName: "vs2017-win2016"
         python.version: "3.9"
         tox.env: py39
+      windows-py35:
+        imageName: "vs2017-win2016"
+        python.version: "3.5"
+        tox.env: py35
       windows-py27:
         imageName: "vs2017-win2016"
         python.version: "2.7"
         tox.env: py27
 
-      macos-py38:
+      macos-py37:
         imageName: "macos-10.14"
-        python.version: "3.8"
-        tox.env: py38
-      macos-py36:
+        python.version: "3.7"
+        tox.env: py37
+      macos-py27:
         imageName: "macos-10.14"
-        python.version: "3.6"
-        tox.env: py36
+        python.version: "2.7"
+        tox.env: py27
 
       linux-pypy3:
         imageName: "ubuntu-20.04"
@@ -31,20 +35,20 @@ jobs:
         imageName: "ubuntu-20.04"
         python.version: "3.10"
         tox.env: py310
-      linux-python-py39-high-memory:
+      linux-python-py38-high-memory:
         imageName: "ubuntu-20.04"
-        python.version: "3.9"
-        tox.env: py39
+        python.version: "3.8"
+        tox.env: py38
         RUN_MEMORY: "true"
       linux-py39-joblib-tests:
         imageName: "ubuntu-20.04"
         python.version: "3.9"
         tox.env: "py39"
         joblib.tests: "true"
-      linux-py35:
+      linux-py36:
         imageName: "ubuntu-20.04"
-        python.version: "3.5"
-        tox.env: py35
+        python.version: "3.6"
+        tox.env: py36
       linux-py27:
         imageName: "ubuntu-20.04"
         python.version: "2.7"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 - Avoid a NameError when calling the `exit` builtin on Windows when
   loky is executed as part of a frozen Python binary. (#290)
 
+- Make it possible to automatically trace workers when profiling with
+  VizTracer (#299).
+
 ### 2.9.0 - 2020-10-02
 
 - Fix a side-effect bug in the registration of custom reducers the loky

--- a/continuous_integration/runtests.sh
+++ b/continuous_integration/runtests.sh
@@ -35,5 +35,5 @@ else
     if [ "$RUN_MEMORY" != "true" ]; then
         PYTEST_ARGS="$PYTEST_ARGS --skip-high-memory"
     fi
-    tox -v -e "${TOX_ENV}"  -- ${PYTEST_ARGS} -x --junitxml="${JUNITXML}"
+    tox -v -e "${TOX_ENV}"  -- ${PYTEST_ARGS} --junitxml="${JUNITXML}"
 fi

--- a/continuous_integration/runtests.sh
+++ b/continuous_integration/runtests.sh
@@ -35,5 +35,5 @@ else
     if [ "$RUN_MEMORY" != "true" ]; then
         PYTEST_ARGS="$PYTEST_ARGS --skip-high-memory"
     fi
-    tox -v -e "${TOX_ENV}"  -- ${PYTEST_ARGS} --junitxml="${JUNITXML}"
+    tox -v -e "${TOX_ENV}"  -- ${PYTEST_ARGS} -x --junitxml="${JUNITXML}"
 fi

--- a/loky/initializers.py
+++ b/loky/initializers.py
@@ -1,0 +1,82 @@
+import warnings
+
+
+def _viztracer_init(init_kwargs):
+    """Initialize viztracer's profiler in worker processes"""
+    from viztracer import VizTracer
+    tracer = VizTracer(**init_kwargs)
+    tracer.register_exit()
+    tracer.start()
+
+
+def _make_viztracer_initializer_and_initargs():
+    try:
+        import viztracer
+        tracer = viztracer.get_tracer()
+        if tracer is not None and getattr(tracer, 'enable', False):
+            # Profiler is active: introspect its configuration to
+            # initialize the workers with the same configuration.
+            return _viztracer_init, (tracer.init_kwargs,)
+    except ImportError:
+        # viztracer is not installed: nothing to do
+        pass
+    except Exception as e:
+        # In case viztracer's API evolve, we do not want to crash loky but
+        # we want to know about it to be able to update loky.
+        warnings.warn("Unable to introspect viztracer state: {}"
+                      .format(e))
+    return None, ()
+
+
+class _ChainedInitializer():
+    """Compound worker initializer
+
+    This is meant to be used in conjunction with _chain_initializers to
+    produce  the necessary chained_args list to be passed to __call__.
+    """
+
+    def __init__(self, initializers):
+        self._initializers = initializers
+
+    def __call__(self, *chained_args):
+        for initializer, args in zip(self._initializers, chained_args):
+            initializer(*args)
+
+
+def _chain_initializers(all_initializers, all_initargs):
+    """Convenience helper to combine a sequence of initializers.
+
+    If some initializers are None, they are filtered out.
+    """
+    filtered_initializers = []
+    filtered_initargs = []
+    for initializer, initargs in zip(all_initializers, all_initargs):
+        if initializer is not None:
+            filtered_initializers.append(initializer)
+            filtered_initargs.append(initargs)
+
+    if len(filtered_initializers) == 0:
+        return None, ()
+    elif len(filtered_initializers) == 1:
+        return filtered_initializers[0], filtered_initargs[0]
+    else:
+        return _ChainedInitializer(filtered_initializers), filtered_initargs
+
+
+def _prepare_initializer(initializer, initargs):
+    if initializer is not None and not callable(initializer):
+        raise TypeError(
+            "initializer must be a callable, got: {!r}"
+            .format(initializer)
+        )
+
+    # Introspect runtime to determine if we need to propagate the viztracer
+    # profiler information to the workers:
+    (
+        viztracer_initializer,
+        viztracer_initargs,
+    ) = _make_viztracer_initializer_and_initargs()
+    return _chain_initializers(
+        [initializer, viztracer_initializer],
+        [initargs, viztracer_initargs],
+    )

--- a/loky/initializers.py
+++ b/loky/initializers.py
@@ -43,14 +43,14 @@ class _ChainedInitializer():
             initializer(*args)
 
 
-def _chain_initializers(all_initializers, all_initargs):
+def _chain_initializers(initializer_and_args):
     """Convenience helper to combine a sequence of initializers.
 
     If some initializers are None, they are filtered out.
     """
     filtered_initializers = []
     filtered_initargs = []
-    for initializer, initargs in zip(all_initializers, all_initargs):
+    for initializer, initargs in initializer_and_args:
         if initializer is not None:
             filtered_initializers.append(initializer)
             filtered_initargs.append(initargs)
@@ -72,11 +72,7 @@ def _prepare_initializer(initializer, initargs):
 
     # Introspect runtime to determine if we need to propagate the viztracer
     # profiler information to the workers:
-    (
-        viztracer_initializer,
-        viztracer_initargs,
-    ) = _make_viztracer_initializer_and_initargs()
-    return _chain_initializers(
-        [initializer, viztracer_initializer],
-        [initargs, viztracer_initargs],
-    )
+    return _chain_initializers([
+        (initializer, initargs),
+        _make_viztracer_initializer_and_initargs(),
+    ])

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -608,7 +608,9 @@ class _ExecutorManagerThread(threading.Thread):
         # of new processes or shut down
         self.processes_management_lock = executor._processes_management_lock
 
-        super(_ExecutorManagerThread, self).__init__()
+        super(_ExecutorManagerThread, self).__init__(
+            name="ExecutorManagerThread"
+        )
         if sys.version_info < (3, 9):
             self.daemon = True
 

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -161,7 +161,7 @@ def _make_viztracer_initializer_and_initargs():
     try:
         import viztracer
         tracer = viztracer.get_tracer()
-        if tracer is not None:
+        if tracer is not None and getattr(tracer, 'enable', False):
             # Profiler is active: introspect its configuration to
             # initialize the workers with the same configuration.
             return _viztracer_init, (tracer.init_kwargs,)

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -1040,8 +1040,8 @@ class ProcessPoolExecutor(_base.Executor):
         if initializer is not None and not callable(initializer):
             raise TypeError("initializer must be a callable")
 
-        # Introspect runtime to determine if we need to propagate the
-        # viztracer profiler information to the workers:
+        # Introspect runtime to determine if we need to propagate the viztracer
+        # profiler information to the workers:
         (
             viztracer_initializer,
             viztracer_initargs,

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -171,7 +171,8 @@ def _make_viztracer_initializer_and_initargs():
     except Exception as e:
         # In case viztracer's API evolve, we do not want to crash loky but
         # we want to know about it to be able to update loky.
-        warnings.warn("Unable to introspect viztracer state: %r" % e)
+        warnings.warn("Unable to introspect viztracer state: {}"
+                      .format(e))
     return None, ()
 
 

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -1085,7 +1085,7 @@ class ExecutorTest:
 
 
 def _custom_initializer():
-    """_custom_init_42 is module function to be picklable
+    """_custom_initializer is module function to be picklable
 
     This is necessary for executor implementations that do not
     use cloudpickle to pickle the initializer.

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -1058,10 +1058,10 @@ class ExecutorTest:
         # Make sure the auto-viztracer initialization works even when
         # the call pass their own init.
         def custom_init():
-            loky.__custom_global_var = 42
+            loky._custom_global_var = 42
 
         def check_viztracer_active_and_custom_init():
-            assert loky.__custom_global_var == 42
+            assert loky._custom_global_var == 42
             tracer = viztracer.get_tracer()
             if tracer is None:
                 return False

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -1,20 +1,4 @@
 from __future__ import print_function
-try:
-    import test.support
-
-    # Skip tests if _multiprocessing wasn't built.
-    test.support.import_module('_multiprocessing')
-    # Skip tests if sem_open implementation is broken.
-    test.support.import_module('multiprocessing.synchronize')
-    # import threading after _multiprocessing to raise a more revelant error
-    # message: "No module named _multiprocessing" if multiprocessing is not
-    # compiled without thread support.
-    test.support.import_module('threading')
-except ImportError:
-    pass
-
-
-# from test.support.script_helper import assert_python_ok
 from loky import process_executor
 
 import os

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -1023,6 +1023,7 @@ class ExecutorTest:
     def test_viztracer_profiler(self):
         # Check that viztracer profiler is initialzed in workers when
         # installed.
+        self.executor.shutdown(wait=True)
         viztracer = pytest.importorskip("viztracer")
 
         def check_viztracer_active():
@@ -1042,9 +1043,12 @@ class ExecutorTest:
             finally:
                 tracer.stop()
 
+        self.check_no_running_workers(patience=2)
+
     def test_viztracer_profiler_with_custom_init(self):
         # Check that viztracer profiler is initialzed in workers when
         # installed.
+        self.executor.shutdown(wait=True)
         viztracer = pytest.importorskip("viztracer")
 
         # Make sure the auto-viztracer initialization works even when
@@ -1070,3 +1074,5 @@ class ExecutorTest:
                     ).result()
             finally:
                 tracer.stop()
+
+        self.check_no_running_workers(patience=2)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
      coverage
      py{27,36}: cython
      cloudpickle ; python_version == '3.5'
-     viztracer ; python_version == '3.7'
+     viztracer ; python_version == '3.8'
      numpy ; python_version >= '3.6' and implementation_name == 'cpython'
      faulthandler ; python_version < '3.3'
 whitelist_externals=

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
      coverage
      py{27,36}: cython
      cloudpickle ; python_version == '3.5'
-     viztracer ; python_version == '3.8'
+     viztracer ; python_version == '3.7'
      numpy ; python_version >= '3.6' and implementation_name == 'cpython'
      faulthandler ; python_version < '3.3'
 whitelist_externals=

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
      coverage
      py{27,36}: cython
      cloudpickle ; python_version == '3.5'
-     viztracer ; python_version == '3.8'
+     viztracer ; python_version >= '3.8' and python_version < '3.10'
      numpy ; python_version >= '3.6' and implementation_name == 'cpython'
      faulthandler ; python_version < '3.3'
 whitelist_externals=

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
      coverage
      py{27,36}: cython
      cloudpickle ; python_version == '3.5'
-     viztracer ; python_version == '3.9'
+     viztracer ; python_version == '3.8'
      numpy ; python_version >= '3.6' and implementation_name == 'cpython'
      faulthandler ; python_version < '3.3'
 whitelist_externals=

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
      coverage
      py{27,36}: cython
      cloudpickle ; python_version == '3.5'
+     viztracer ; python_version == '3.9'
      numpy ; python_version >= '3.6' and implementation_name == 'cpython'
      faulthandler ; python_version < '3.3'
 whitelist_externals=

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, pypy3
+envlist = py27, py35, py36, py37, py38, py39, py310, pypy3
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
Fix #297.

- [x] write some tests
- [x] <del>define an initializer registry?</del>

I decided to move the registry design discussion to a later issue.

To write such a registry we need take into account several design constraints into account:

- per-worker vs per-function-call contexts with setup/teardown (see: https://github.com/scikit-learn/scikit-learn/blob/3ae7c7615343bbd36acece57825d8b0d70fd9da4/sklearn/utils/fixes.py#L189-L196)
- thread-safety / side effect isolation of per-function-call contexts for threadpool executors / dask executors with multiple threads per workers
- shall we allow custom teardowns for per-worker inits?

VizTracer would only be one use case. sklearn, pandas and warnings config would be others.