### PR TITLE
MAINT make tests pass on macOS 11

### DIFF
--- a/loky/backend/synchronize.py
+++ b/loky/backend/synchronize.py
@@ -60,23 +60,29 @@ class SemLock(object):
 
     _rand = tempfile._RandomNameSequence()
 
-    def __init__(self, kind, value, maxvalue):
+    def __init__(self, kind, value, maxvalue, name=None):
         # unlink_now is only used on win32 or when we are using fork.
         unlink_now = False
-        for i in range(100):
-            try:
-                self._semlock = _SemLock(
-                    kind, value, maxvalue, SemLock._make_name(),
-                    unlink_now)
-            except FileExistsError:  # pragma: no cover
-                pass
-            else:
-                break
-        else:  # pragma: no cover
-            raise FileExistsError('cannot find name for semaphore')
-
+        if name is None:
+            # Try to find an unused name for the SemLock instance.
+            for i in range(100):
+                try:
+                    self._semlock = _SemLock(
+                        kind, value, maxvalue, SemLock._make_name(), unlink_now
+                    )
+                except FileExistsError:  # pragma: no cover
+                    pass
+                else:
+                    break
+            else:  # pragma: no cover
+                raise FileExistsError('cannot find name for semaphore')
+        else:
+            self._semlock = _SemLock(
+                kind, value, maxvalue, name, unlink_now
+            )
+        self.name = name
         util.debug('created semlock with handle %s and name "%s"'
-                   % (self._semlock.handle, self._semlock.name))
+                   % (self._semlock.handle, self.name))
 
         self._make_methods()
 

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -31,6 +31,8 @@ class TestResourceTracker:
     @pytest.mark.parametrize("rtype", ["file", "folder", "semlock"])
     def test_resource_utils(self, rtype):
         # Check that the resouce utils work as expected in the main process
+        if sys.platform == "win32" and rtype == "semlock":
+            pytest.skip("no semlock on windows")
         name = create_resource(rtype)
         assert resource_exists(name, rtype)
         resource_unlink(name, rtype)

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -1,14 +1,12 @@
 """Tests for the ResourceTracker class"""
 import errno
 import gc
-import io
 import os
 import pytest
 import re
 import signal
 import subprocess
 import sys
-import tempfile
 import time
 import warnings
 import weakref
@@ -16,6 +14,7 @@ import weakref
 from loky import ProcessPoolExecutor
 import loky.backend.resource_tracker as resource_tracker
 from loky.backend.context import get_context
+from .utils import resource_unlink, create_resource, resource_exists
 
 
 def _resource_unlink(name, rtype):
@@ -28,6 +27,15 @@ def get_rtracker_pid():
 
 
 class TestResourceTracker:
+
+    @pytest.mark.parametrize("rtype", ["file", "folder", "semlock"])
+    def test_resource_utils(self, rtype):
+        # Check that the resouce utils work as expected in the main process
+        name = create_resource(rtype)
+        assert resource_exists(name, rtype)
+        resource_unlink(name, rtype)
+        assert not resource_exists(name, rtype)
+
     def test_child_retrieves_resource_tracker(self):
         parent_rtracker_pid = get_rtracker_pid()
         executor = ProcessPoolExecutor(max_workers=2)
@@ -45,7 +53,6 @@ class TestResourceTracker:
 
         from loky import ProcessPoolExecutor
         from loky.backend import resource_tracker
-        from loky.backend.semlock import SemLock
         from tempfile import NamedTemporaryFile
 
 
@@ -102,9 +109,7 @@ class TestResourceTracker:
         import subprocess
         cmd = '''if 1:
             import time, os, tempfile, sys
-
-            from loky.backend.semlock import SemLock
-            from loky.backend import resource_tracker, reduction
+            from loky.backend import resource_tracker
             from utils import create_resource
 
             for _ in range(2):
@@ -170,7 +175,6 @@ class TestResourceTracker:
         import os
         import tempfile
         import time
-        from loky.backend.semlock import SemLock, _sem_open
         from loky.backend import resource_tracker
         from utils import resource_unlink, create_resource, resource_exists
 

--- a/tests/test_synchronize.py
+++ b/tests/test_synchronize.py
@@ -21,7 +21,8 @@ if sys.version_info < (3, 3):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="UNIX test")
 def test_semlock_failure():
-    from loky.backend.semlock import SemLock, sem_unlink
+    from loky.backend.synchronize import SemLock, sem_unlink
+
     name = "loky-test-semlock"
     sl = SemLock(0, 1, 1, name=name)
 
@@ -30,7 +31,7 @@ def test_semlock_failure():
     sem_unlink(sl.name)
 
     with pytest.raises(FileNotFoundError):
-        SemLock._rebuild(None, 0, 0, name)
+        sl._semlock._rebuild(0, 0, 0, name)
 
 
 def assert_sem_value_equal(sem, value):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -57,7 +57,7 @@ def resource_exists(name, rtype):
             _SemLock(1, 1, 1, name, False)
             sem_unlink(name)
             return False
-        except FileExistsError:
+        except OSError:
             return True
     else:
         raise ValueError("Resource type %s not understood" % rtype)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,15 +7,22 @@ import warnings
 import threading
 import subprocess
 import contextlib
-from tempfile import mkstemp, mkdtemp, NamedTemporaryFile
+from tempfile import mkstemp, mkdtemp, NamedTemporaryFile, _RandomNameSequence
 from loky.backend import resource_tracker
-from loky.backend.semlock import SemLock, _sem_open
+if sys.version_info < (3, 4):
+    from .semlock import SemLock as _SemLock
+    from .semlock import sem_unlink
+else:
+    from _multiprocessing import SemLock as _SemLock
+    from _multiprocessing import sem_unlink
 
 try:
     FileNotFoundError = FileNotFoundError
 except NameError:  # FileNotFoundError is Python 3-only
     from loky.backend.semlock import FileNotFoundError
 
+
+_rand_name = _RandomNameSequence()
 
 if sys.version_info[0] == 2:
     class TimeoutError(OSError):
@@ -31,8 +38,8 @@ def create_resource(rtype):
         return mkdtemp(dir=os.getcwd())
 
     elif rtype == "semlock":
-        name = "loky-%i-%s" % (os.getpid(), next(SemLock._rand))
-        _ = SemLock(1, 1, 1, name)
+        name = "test-loky-%i-%s" % (os.getpid(), next(_rand_name))
+        _SemLock(1, 1, 1, name, False)
         return name
     elif rtype == "file":
         tmpfile = NamedTemporaryFile(delete=False)
@@ -46,15 +53,12 @@ def resource_exists(name, rtype):
     if rtype in ["folder", "file"]:
         return os.path.exists(name)
     elif rtype == "semlock":
-        # On OSX, semaphore are not visible in the file system, we must
-        # try to open the semaphore to check if it exists.
-        from loky.backend.semlock import pthread
         try:
-            h = _sem_open(name.encode('ascii'))
-            pthread.sem_close(h)
-            return True
-        except FileNotFoundError:
+            _SemLock(1, 1, 1, name, False)
+            sem_unlink(name)
             return False
+        except FileExistsError:
+            return True
     else:
         raise ValueError("Resource type %s not understood" % rtype)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,8 +10,8 @@ import contextlib
 from tempfile import mkstemp, mkdtemp, NamedTemporaryFile, _RandomNameSequence
 from loky.backend import resource_tracker
 if sys.version_info < (3, 4):
-    from .semlock import SemLock as _SemLock
-    from .semlock import sem_unlink
+    from loky.backend.semlock import SemLock as _SemLock
+    from loky.backend.semlock import sem_unlink
 else:
     from _multiprocessing import SemLock as _SemLock
     from _multiprocessing import sem_unlink


### PR DESCRIPTION
The ctypes-based implementation of `SemLock` for Python 2.7 does not work on macOS 11 and I have no idea why (I get `EINVAL` randomly when creating new semlocks).

It works with the `_multiprocessing` implementation though, so in practice `loky` works fine with recent versions of Python on macOS 11. So instead of trying to fix the ctypes implementation, I changed the test to use `_multiprocessing`  when available.

We might want to get rid of Python 2.7 support and the ctypes implementation of semlock to lower the maintenance burden. This PR is a first tiny step in that direction.