### PR TITLE
Fix random failure in test_interpreter_shutdown and improve a failure message in test_hang_issue39205

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ### 3.1.0 - XXXX-XX-XX
 
+- Fix an exception that could be raised in an auxiliary thread when
+  garbage collecting an executor instance when shutting down the
+  the Python interpreter (#311).
+
 
 ### 3.0.0 - 2021-09-10
 

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -514,8 +514,12 @@ class _ExecutorManagerThread(threading.Thread):
         def weakref_cb(_,
                        thread_wakeup=self.thread_wakeup,
                        shutdown_lock=self.shutdown_lock):
-            mp.util.debug('Executor collected: triggering callback for'
-                          ' QueueManager wakeup')
+            if mp is not None:
+                # At this point, the multiprocessing module can already be
+                # garbage collected. We only log debug info when still
+                # possible.
+                mp.util.debug('Executor collected: triggering callback for'
+                              ' QueueManager wakeup')
             with shutdown_lock:
                 thread_wakeup.wakeup()
 

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -135,11 +135,14 @@ class ExecutorShutdownTest:
             stdout, stderr = check_subprocess_call(
                 [sys.executable, "-c", code], timeout=55)
 
-            # On OSX, remove UserWarning for broken semaphores
             if sys.platform == "darwin":
-                stderr = [e for e in stderr.strip().split("\n")
-                          if "increase its maximal value" not in e]
-            assert len(stderr) == 0 or stderr[0] == ''
+                # On macOS, ignore serWarning for broken semaphores
+                stderr = "\n".join(
+                    line
+                    for line in stderr.splitlines()
+                    if "increase its maximal value" not in line
+                )
+            assert len(stderr) == 0, stderr
 
             # The workers should have completed their work before the main
             # process exits:

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -85,6 +85,18 @@ class MyObject(object):
         pass
 
 
+def _assert_no_error(stderr):
+    if sys.platform == "darwin":
+        # On macOS, ignore UserWarning related to their broken semaphore
+        # implementation.
+        stderr = "\n".join(
+            line
+            for line in stderr.splitlines()
+            if "increase its maximal value" not in line
+        )
+    assert len(stderr) == 0, stderr
+
+
 class ExecutorShutdownTest:
 
     def test_run_after_shutdown(self):
@@ -135,14 +147,7 @@ class ExecutorShutdownTest:
             stdout, stderr = check_subprocess_call(
                 [sys.executable, "-c", code], timeout=55)
 
-            if sys.platform == "darwin":
-                # On macOS, ignore serWarning for broken semaphores
-                stderr = "\n".join(
-                    line
-                    for line in stderr.splitlines()
-                    if "increase its maximal value" not in line
-                )
-            assert len(stderr) == 0, stderr
+            _assert_no_error(stderr)
 
             # The workers should have completed their work before the main
             # process exits:
@@ -390,11 +395,7 @@ class ExecutorShutdownTest:
         stdout, stderr = check_subprocess_call(
                 [sys.executable, "-c", code], timeout=55)
 
-        # On OSX, remove UserWarning for broken semaphores
-        if sys.platform == "darwin":
-            stderr = [e for e in stderr.strip().split("\n")
-                      if "increase its maximal value" not in e]
-        assert len(stderr) == 0 or stderr[0] == ''
+        _assert_no_error(stderr)
         assert stdout.strip() == "apple"
 
     @classmethod


### PR DESCRIPTION
This test is failing on my machine. With the new code, the error message is more informative:

```python-traceback
E           AssertionError: Exception ignored in: <function _ExecutorManagerThread.__init__.<locals>.weakref_cb at 0x118f8a3a0>
E           Traceback (most recent call last):
E             File "/Users/ogrisel/code/loky/loky/process_executor.py", line 517, in weakref_cb
E           AttributeError: 'NoneType' object has no attribute 'util'
```

but the test can be improved without waiting for a fix for this bug it the CI is green.