### PR TITLE
Make time relative test failures more informative

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -112,11 +112,15 @@ class TimingWrapper(object):
         finally:
             self.elapsed = time.time() - t
 
-    def assert_timing_almost_equal(self, delay):
-        assert round(self.elapsed - delay, 1) == 0
+    def assert_timing_lower_than(self, delay):
+        msg = (
+            f"expected duration lower than {delay:.3f}s, "
+            f"got {self.elapsed:.3f}s"
+        )
+        assert self.elapsed < delay, msg
 
     def assert_timing_almost_zero(self):
-        self.assert_timing_almost_equal(0.0)
+        self.assert_timing_lower_than(0.1)
 
 
 #


### PR DESCRIPTION
The following tiny refactoring should give us more informative failure messages.