### PR TITLE
MNT drop py < 3.7 support for process_executor and reusable_executor

### DIFF
--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -79,9 +79,6 @@ from multiprocessing.connection import wait
 
 from . import _base
 from .backend import get_context
-from .backend.compat import queue
-from .backend.compat import wait
-from .backend.compat import set_cause
 from .backend.context import cpu_count
 from .backend.queues import Queue, SimpleQueue
 from .backend.reduction import set_loky_pickler, get_loky_pickler_name

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from loky import process_executor
 
 import os
@@ -14,24 +13,21 @@ import traceback
 import threading
 import faulthandler
 from math import sqrt
+from pickle import PicklingError
 from threading import Thread
 from collections import defaultdict
+from concurrent import futures
+from concurrent.futures._base import (PENDING, RUNNING, CANCELLED,
+                                      CANCELLED_AND_NOTIFIED, FINISHED)
 
 import loky
 from loky.process_executor import LokyRecursionError
 from loky.process_executor import ShutdownExecutorError, TerminatedWorkerError
-from loky._base import (PENDING, RUNNING, CANCELLED, CANCELLED_AND_NOTIFIED,
-                        FINISHED, Future)
+from loky._base import Future
 
 from . import _executor_mixin
 from .utils import id_sleep, check_subprocess_call, filter_match
-from .test_reusable_executor import ErrorAtPickle, ExitAtPickle
-from .test_reusable_executor import PICKLING_ERRORS, c_exit
-
-if sys.version_info[:2] < (3, 3):
-    import loky._base as futures
-else:
-    from concurrent import futures
+from .test_reusable_executor import ErrorAtPickle, ExitAtPickle, c_exit
 
 
 IS_PYPY = hasattr(sys, "pypy_version_info")
@@ -74,7 +70,7 @@ def sleep_and_write(t, filename, msg):
         f.write(str(msg).encode('utf-8'))
 
 
-class MyObject(object):
+class MyObject:
     def __init__(self, value=0):
         self.value = value
 
@@ -267,7 +263,7 @@ class ExecutorShutdownTest:
 
         # The crashing job should be executed after the non-failing jobs
         # have completed. The crash should be detected.
-        match = filter_match(r"SIGSEGV", self.context.get_start_method())
+        match = filter_match(r"SIGSEGV")
         with pytest.raises(TerminatedWorkerError, match=match):
             crash_result.result()
 
@@ -367,7 +363,7 @@ class ExecutorShutdownTest:
             # without waiting
             f = executor.submit(id, ErrorAtPickle())
             executor.shutdown(wait=False)
-            with pytest.raises(PICKLING_ERRORS):
+            with pytest.raises(PicklingError):
                 f.result()
 
         # Make sure the executor is eventually shutdown and do not leave
@@ -393,7 +389,7 @@ class ExecutorShutdownTest:
             e.shutdown(wait=False)
         """
         stdout, stderr = check_subprocess_call(
-                [sys.executable, "-c", code], timeout=55)
+            [sys.executable, "-c", code], timeout=55)
 
         _assert_no_error(stderr)
         assert stdout.strip() == "apple"
@@ -415,13 +411,6 @@ class ExecutorShutdownTest:
             f.result()
 
     def test_recursive_kill(self):
-        if (self.context.get_start_method() == 'forkserver' and
-                sys.version_info < (3, 7)):
-            # Before python3.7, the forserver was shared with the child
-            # processes so there is no way to detect the children of a given
-            # process for recursive_kill. This break the test.
-            pytest.skip("Need python3.7+")
-
         f = self.executor.submit(self._test_recursive_kill, 1)
         # Wait for the nested executors to be started
         _executor_mixin._test_event.wait()
@@ -448,8 +437,8 @@ class WaitTests:
         done, not_done = futures.wait([CANCELLED_FUTURE, future1, future2],
                                       return_when=futures.FIRST_COMPLETED)
 
-        assert set([future1]) == done
-        assert set([CANCELLED_FUTURE, future2]) == not_done
+        assert {future1} == done
+        assert {CANCELLED_FUTURE, future2} == not_done
 
     def test_first_completed_some_already_completed(self):
         future1 = self.executor.submit(time.sleep, 1.5)
@@ -458,9 +447,8 @@ class WaitTests:
                                           SUCCESSFUL_FUTURE, future1],
                                          return_when=futures.FIRST_COMPLETED)
 
-        assert (set([CANCELLED_AND_NOTIFIED_FUTURE, SUCCESSFUL_FUTURE]) ==
-                finished)
-        assert set([future1]) == pending
+        assert {CANCELLED_AND_NOTIFIED_FUTURE, SUCCESSFUL_FUTURE} == finished
+        assert {future1} == pending
 
     @classmethod
     def wait_and_raise(cls, t):
@@ -486,8 +474,8 @@ class WaitTests:
 
         assert _executor_mixin._test_event.is_set()
 
-        assert set([future1, future2]) == finished
-        assert set([future3]) == pending
+        assert {future1, future2} == finished
+        assert {future3} == pending
 
         _executor_mixin._test_event.clear()
 
@@ -500,9 +488,8 @@ class WaitTests:
                                           future1, future2],
                                          return_when=futures.FIRST_EXCEPTION)
 
-        assert set([SUCCESSFUL_FUTURE, CANCELLED_AND_NOTIFIED_FUTURE,
-                    future1]) == finished
-        assert set([CANCELLED_FUTURE, future2]) == pending
+        assert {SUCCESSFUL_FUTURE, CANCELLED_AND_NOTIFIED_FUTURE, future1} == finished
+        assert {CANCELLED_FUTURE, future2} == pending
 
     def test_first_exception_one_already_failed(self):
         future1 = self.executor.submit(time.sleep, 2)
@@ -510,8 +497,8 @@ class WaitTests:
         finished, pending = futures.wait([EXCEPTION_FUTURE, future1],
                                          return_when=futures.FIRST_EXCEPTION)
 
-        assert set([EXCEPTION_FUTURE]) == finished
-        assert set([future1]) == pending
+        assert {EXCEPTION_FUTURE} == finished
+        assert {future1} == pending
 
     def test_all_completed(self):
         future1 = self.executor.submit(divmod, 2, 0)
@@ -522,9 +509,9 @@ class WaitTests:
                                           future1, future2],
                                          return_when=futures.ALL_COMPLETED)
 
-        assert set([SUCCESSFUL_FUTURE, CANCELLED_AND_NOTIFIED_FUTURE,
-                    EXCEPTION_FUTURE, future1, future2]) == finished
-        assert set() == pending
+        assert {SUCCESSFUL_FUTURE, CANCELLED_AND_NOTIFIED_FUTURE,
+                EXCEPTION_FUTURE, future1, future2} == finished
+        assert not pending
 
     def test_timeout(self):
         # Make sure the executor has already started to avoid timeout happening
@@ -542,9 +529,9 @@ class WaitTests:
                                          timeout=.1,
                                          return_when=futures.ALL_COMPLETED)
 
-        assert set([CANCELLED_AND_NOTIFIED_FUTURE, EXCEPTION_FUTURE,
-                    SUCCESSFUL_FUTURE, future1]) == finished
-        assert set([future2]) == pending
+        assert {CANCELLED_AND_NOTIFIED_FUTURE, EXCEPTION_FUTURE,
+                SUCCESSFUL_FUTURE, future1} == finished
+        assert {future2} == pending
 
         _executor_mixin._test_event.set()
         assert future2.result(timeout=10)
@@ -561,8 +548,8 @@ class AsCompletedTests:
                                               EXCEPTION_FUTURE,
                                               SUCCESSFUL_FUTURE,
                                               future1, future2]))
-        assert set([CANCELLED_AND_NOTIFIED_FUTURE, EXCEPTION_FUTURE,
-                    SUCCESSFUL_FUTURE, future1, future2]) == completed
+        assert {CANCELLED_AND_NOTIFIED_FUTURE, EXCEPTION_FUTURE,
+                SUCCESSFUL_FUTURE, future1, future2} == completed
 
     def test_zero_timeout(self):
         future1 = self.executor.submit(time.sleep, 2)
@@ -576,14 +563,14 @@ class AsCompletedTests:
                     timeout=0):
                 completed_futures.add(future)
 
-        assert set([CANCELLED_AND_NOTIFIED_FUTURE, EXCEPTION_FUTURE,
-                    SUCCESSFUL_FUTURE]) == completed_futures
+        assert {CANCELLED_AND_NOTIFIED_FUTURE, EXCEPTION_FUTURE,
+                SUCCESSFUL_FUTURE} == completed_futures
 
     def test_duplicate_futures(self):
         # Issue 20367. Duplicate futures should not raise exceptions or give
         # duplicate responses.
         future1 = self.executor.submit(time.sleep, .1)
-        completed = [f for f in futures.as_completed([future1, future1])]
+        completed = list(futures.as_completed([future1, future1]))
         assert len(completed) == 1
 
 
@@ -599,7 +586,7 @@ class ExecutorTest:
         assert 16 == future.result()
 
     def test_map(self):
-        assert list(self.executor.map(pow, range(10), range(10))) ==\
+        assert list(self.executor.map(pow, range(10), range(10))) == \
             list(map(pow, range(10), range(10)))
 
     def test_map_exception(self):
@@ -639,13 +626,13 @@ class ExecutorTest:
         # https://bugs.python.org/issue39492
         my_object = MyObject()
         collect = threading.Event()
-        _ = weakref.ref(my_object, lambda obj: collect.set())  # noqa
+        _ref = weakref.ref(my_object, lambda obj: collect.set())  # noqa
         # Deliberately discarding the future.
         self.executor.submit(my_object.my_method)
         del my_object
 
         collected = False
-        for i in range(5):
+        for _ in range(5):
             if IS_PYPY:
                 gc.collect()
             collected = collect.wait(timeout=1.0)
@@ -667,7 +654,7 @@ class ExecutorTest:
         # Get one of the processes, and terminate (kill) it
         p = next(iter(self.executor._processes.values()))
         p.terminate()
-        match = filter_match(r"SIGTERM", self.context.get_start_method())
+        match = filter_match(r"SIGTERM")
         with pytest.raises(TerminatedWorkerError, match=match):
             future.result()
         # Submitting other jobs fails as well.
@@ -701,13 +688,7 @@ class ExecutorTest:
 
         exc = cm.value
         assert type(exc) is RuntimeError
-        if sys.version_info > (3,):
-            assert exc.args == (123,)
-        else:
-            assert exc.args[0].startswith("123")
-            # Makes sure that the cause of the RuntimeError is properly
-            # reported in the error message.
-            assert "raise RuntimeError(123)  # some comment" in exc.args[0]
+        assert exc.args == (123,)
 
         cause = exc.__cause__
         assert type(cause) is process_executor._RemoteTraceback
@@ -728,7 +709,7 @@ class ExecutorTest:
                 # another
                 time.sleep(0.001)
             submit_futures = [self.executor.submit(time.sleep, 0.0001)
-                              for i in range(20)]
+                              for _ in range(20)]
             for i, f in enumerate(submit_futures):
                 if i % 2 == 0:
                     f.cancel()
@@ -747,11 +728,10 @@ class ExecutorTest:
     def test_thread_safety(self):
         # Check that our process-pool executor can be shared to schedule work
         # by concurrent threads
-        threads = []
         results = [None] * 10
-        for i in range(len(results)):
-            threads.append(Thread(target=self._test_thread_safety,
-                                  args=(i, results)))
+        threads = [Thread(target=self._test_thread_safety, args=(i, results))
+                   for i in range(len(results))]
+
         for t in threads:
             t.start()
         for t in threads:
@@ -812,9 +792,9 @@ class ExecutorTest:
         except NotImplementedError as e:
             self.skipTest(str(e))
 
-        for i in range(5):
+        for _ in range(5):
             # Trigger worker spawn for lazy executor implementations
-            for result in self.executor.map(id, range(8)):
+            for _ in self.executor.map(id, range(8)):
                 pass
 
             # Check that all workers shutdown (via timeout) when waiting a bit:
@@ -895,8 +875,8 @@ class ExecutorTest:
     @pytest.mark.skipif(sys.maxsize < 2 ** 32,
                         reason="Test requires a 64 bit version of Python")
     @pytest.mark.skipif(
-            sys.version_info[:2] < (3, 8),
-            reason="Python version does not support pickling objects of size > 2 ** 31GB")
+        sys.version_info < (3, 8),
+        reason="Python version does not support pickling objects of size > 2 ** 31GB")
     def test_no_failure_on_large_data_send(self):
         data = b'\x00' * int(2.2e9)
         self.executor.submit(id, data).result()
@@ -905,8 +885,8 @@ class ExecutorTest:
     @pytest.mark.skipif(sys.maxsize < 2 ** 32,
                         reason="Test requires a 64 bit version of Python")
     @pytest.mark.skipif(
-            sys.version_info[:2] >= (3, 8),
-            reason="Python version supports pickling objects of size > 2 ** 31GB")
+        sys.version_info >= (3, 8),
+        reason="Python version supports pickling objects of size > 2 ** 31GB")
     def test_expected_failure_on_large_data_send(self):
         data = b'\x00' * int(2.2e9)
         with pytest.raises(RuntimeError):
@@ -935,11 +915,9 @@ class ExecutorTest:
             return os.getpid(), leaked_size
 
         with pytest.warns(UserWarning, match='memory leak'):
-            futures = []
-            for i in range(300):
-                # Total run time should be 3s which is way over the 1s cooldown
-                # period between two consecutive memory checks in the worker.
-                futures.append(executor.submit(_leak_some_memory))
+            # Total run time should be 3s which is way over the 1s cooldown
+            # period between two consecutive memory checks in the worker.
+            futures = [executor.submit(_leak_some_memory) for _ in range(300)]
 
             executor.shutdown(wait=True)
             results = [f.result() for f in futures]
@@ -979,11 +957,9 @@ class ExecutorTest:
             os._loky_cyclic_weakrefs.append(weakref.ref(a))
             return sum(1 for r in os._loky_cyclic_weakrefs if r() is not None)
 
-        futures = []
-        for i in range(300):
-            # Total run time should be 3s which is way over the 1s cooldown
-            # period between two consecutive memory checks in the worker.
-            futures.append(executor.submit(_create_cyclic_reference))
+        # Total run time should be 3s which is way over the 1s cooldown
+        # period between two consecutive memory checks in the worker.
+        futures = [executor.submit(_create_cyclic_reference) for _ in range(300)]
 
         executor.shutdown(wait=True)
 
@@ -996,7 +972,7 @@ class ExecutorTest:
         # When a child process is abruptly terminated, the whole pool gets
         # "broken".
         print(self.context.get_start_method())
-        match = filter_match(r"EXIT\(42\)", self.context.get_start_method())
+        match = filter_match(r"EXIT\(42\)")
         future = self.executor.submit(c_exit, 42)
         with pytest.raises(TerminatedWorkerError, match=match):
             future.result()

--- a/tests/test_process_executor_forkserver.py
+++ b/tests/test_process_executor_forkserver.py
@@ -5,38 +5,32 @@ from loky.backend import get_context
 from ._executor_mixin import ExecutorMixin
 
 
-if (sys.version_info[:2] > (3, 3)
-        and sys.platform != "win32"
-        and not hasattr(sys, "pypy_version_info")):
+if sys.platform != "win32" and not hasattr(sys, "pypy_version_info"):
     # XXX: the forkserver backend is broken with pypy3.
+    from ._test_process_executor import (
+        AsCompletedTests,
+        ExecutorShutdownTest,
+        ExecutorTest,
+        WaitTests
+    )
 
     class ProcessPoolForkserverMixin(ExecutorMixin):
         executor_type = process_executor.ProcessPoolExecutor
         context = get_context('forkserver')
-
-    from ._test_process_executor import ExecutorShutdownTest
 
     class TestsProcessPoolForkserverShutdown(ProcessPoolForkserverMixin,
                                              ExecutorShutdownTest):
         def _prime_executor(self):
             pass
 
-    from ._test_process_executor import WaitTests
-
     class TestsProcessPoolForkserverWait(ProcessPoolForkserverMixin,
                                          WaitTests):
         pass
-
-    from ._test_process_executor import AsCompletedTests
 
     class TestsProcessPoolForkserverAsCompleted(ProcessPoolForkserverMixin,
                                                 AsCompletedTests):
         pass
 
-    from ._test_process_executor import ExecutorTest
-
     class TestsProcessPoolForkserverExecutor(ProcessPoolForkserverMixin,
                                              ExecutorTest):
         pass
-
-    from ._test_process_executor import ExecutorTest

--- a/tests/test_process_executor_spawn.py
+++ b/tests/test_process_executor_spawn.py
@@ -5,33 +5,29 @@ from loky.backend import get_context
 from ._executor_mixin import ExecutorMixin
 
 
-if (sys.version_info[:2] > (3, 3)
-        and not hasattr(sys, "pypy_version_info")):
+if not hasattr(sys, "pypy_version_info"):
+    from ._test_process_executor import (
+        AsCompletedTests,
+        ExecutorShutdownTest,
+        ExecutorTest,
+        WaitTests
+    )
+
     class ProcessPoolSpawnMixin(ExecutorMixin):
         executor_type = process_executor.ProcessPoolExecutor
         context = get_context('spawn')
-
-    from ._test_process_executor import ExecutorShutdownTest
 
     class TestsProcessPoolSpawnShutdown(ProcessPoolSpawnMixin,
                                         ExecutorShutdownTest):
         def _prime_executor(self):
             pass
 
-    from ._test_process_executor import WaitTests
-
     class TestsProcessPoolSpawnWait(ProcessPoolSpawnMixin, WaitTests):
         pass
-
-    from ._test_process_executor import AsCompletedTests
 
     class TestsProcessPoolSpawnAsCompleted(ProcessPoolSpawnMixin,
                                            AsCompletedTests):
         pass
 
-    from ._test_process_executor import ExecutorTest
-
     class TestsProcessPoolSpawnExecutor(ProcessPoolSpawnMixin, ExecutorTest):
         pass
-
-    from ._test_process_executor import ExecutorTest

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -40,27 +40,19 @@ try:
 except ImportError:
     np = None
 
-# Backward compat for python2 cPickle module
-PICKLING_ERRORS = (PicklingError,)
-try:
-    import cPickle
-    PICKLING_ERRORS += (cPickle.PicklingError,)
-except ImportError:
-    pass
-
 
 def clean_warning_registry():
     """Safe way to reset warnings."""
     warnings.resetwarnings()
     reg = "__warningregistry__"
-    for mod_name, mod in list(sys.modules.items()):
+    for mod in list(sys.modules.values()):
         if hasattr(mod, reg):
             getattr(mod, reg).clear()
 
 
 def wait_dead(worker, n_tries=1000, delay=0.001):
     """Wait for process pid to die"""
-    for i in range(n_tries):
+    for _ in range(n_tries):
         if worker.exitcode is not None:
             return
         sleep(delay)
@@ -132,43 +124,43 @@ def do_nothing(arg):
     return True
 
 
-class CrashAtPickle(object):
+class CrashAtPickle:
     """Bad object that triggers a segfault at pickling time."""
     def __reduce__(self):
         crash()
 
 
-class CrashAtUnpickle(object):
+class CrashAtUnpickle:
     """Bad object that triggers a segfault at unpickling time."""
     def __reduce__(self):
         return crash, ()
 
 
-class ExitAtPickle(object):
+class ExitAtPickle:
     """Bad object that triggers a segfault at pickling time."""
     def __reduce__(self):
         exit()
 
 
-class ExitAtUnpickle(object):
+class ExitAtUnpickle:
     """Bad object that triggers a process exit at unpickling time."""
     def __reduce__(self):
         return exit, ()
 
 
-class CExitAtPickle(object):
+class CExitAtPickle:
     """Bad object that triggers a segfault at pickling time."""
     def __reduce__(self):
         c_exit()
 
 
-class CExitAtUnpickle(object):
+class CExitAtUnpickle:
     """Bad object that triggers a process exit at unpickling time."""
     def __reduce__(self):
         return c_exit, ()
 
 
-class ErrorAtPickle(object):
+class ErrorAtPickle:
     """Bad object that raises an error at pickling time."""
     def __init__(self, fail=True):
         self.fail = fail
@@ -180,7 +172,7 @@ class ErrorAtPickle(object):
             return id, (42, )
 
 
-class ErrorAtUnpickle(object):
+class ErrorAtUnpickle:
     """Bad object that triggers a process exit at unpickling time."""
     def __init__(self, etype=UnpicklingError, message='the error message'):
         self.etype = etype
@@ -190,14 +182,14 @@ class ErrorAtUnpickle(object):
         return raise_error, (self.etype, self.message)
 
 
-class CrashAtGCInWorker(object):
+class CrashAtGCInWorker:
     """Bad object that triggers a segfault at call item GC time"""
     def __del__(self):
         if current_process().name != "MainProcess":
             crash()
 
 
-class CExitAtGCInWorker(object):
+class CExitAtGCInWorker:
     """Exit worker at call item GC time"""
     def __del__(self):
         if current_process().name != "MainProcess":
@@ -365,7 +357,7 @@ class TestExecutorDeadLock(ReusableExecutorMixin):
         res = executor.map(sleep_then_check_pids_exist,
                            [(.0001 * (j // 2), pids)
                             for j in range(2 * n_proc)])
-        assert all(list(res))
+        assert all(res)
         with pytest.raises(TerminatedWorkerError,
                            match=filter_match(r"SIGKILL")):
             res = executor.map(kill_friend, pids[::-1])
@@ -393,9 +385,9 @@ class TestExecutorDeadLock(ReusableExecutorMixin):
     def test_queue_full_deadlock(self):
         executor = get_reusable_executor(max_workers=1)
         fs_fail = [executor.submit(do_nothing, ErrorAtPickle(True))
-                   for i in range(100)]
+                   for _ in range(100)]
         fs = [executor.submit(do_nothing, ErrorAtPickle(False))
-              for i in range(100)]
+              for _ in range(100)]
         with pytest.raises(PicklingError):
             fs_fail[99].result()
         assert fs[99].result()
@@ -481,7 +473,7 @@ class TestTerminateExecutor(ReusableExecutorMixin):
         # when processing subsequently dispatched tasks:
         with pytest.raises(TerminatedWorkerError, match=filter_match(match)):
             executor.submit(gc.collect).result()
-            for r in executor.map(sleep, [.1] * 100):
+            for _ in executor.map(sleep, [.1] * 100):
                 pass
 
 
@@ -594,8 +586,6 @@ class TestGetReusableExecutor(ReusableExecutorMixin):
             executor._resize(max_workers=None)
 
     @pytest.mark.skipif(sys.platform == "win32", reason="No fork on windows")
-    @pytest.mark.skipif(sys.version_info <= (3, 4),
-                        reason="No context before 3.4")
     def test_invalid_context(self):
         """Raise error on invalid context"""
 
@@ -722,7 +712,7 @@ class TestGetReusableExecutor(ReusableExecutorMixin):
         # Ensure that loky.Future are compatible with concurrent.futures
         # (see #155)
         assert isinstance(f, concurrent.futures.Future)
-        (done, running) = concurrent.futures.wait([f], timeout=15)
+        _, running = concurrent.futures.wait([f], timeout=15)
         assert len(running) == 0
 
     thread_configurations = [
@@ -750,7 +740,7 @@ class TestGetReusableExecutor(ReusableExecutorMixin):
             with warnings.catch_warnings():  # ignore resize warnings
                 warnings.simplefilter("always")
                 executor = get_reusable_executor(max_workers=max_workers)
-                for i in range(n_outer_steps):
+                for _ in range(n_outer_steps):
                     results = executor.map(
                         lambda x: x ** 2, range(n_inner_steps))
                     expected_result = [x ** 2 for x in range(n_inner_steps)]


### PR DESCRIPTION
Part of https://github.com/joblib/loky/pull/304. Remove py < 3.7 support in process_executor and reusable_executor