### PR TITLE
Fix inconsistency in unstable test_terminate

### DIFF
--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -349,6 +349,7 @@ class TestLokyBackend:
 
         p.terminate()
 
+        MAX_JOIN_TIME = 10
         if hasattr(signal, 'alarm'):
             # On the Gentoo buildbot waitpid() often seems to block forever.
             # We use alarm() to interrupt it if it blocks for too long.
@@ -356,7 +357,7 @@ class TestLokyBackend:
                 raise RuntimeError(f'join took too long: {p}')
             old_handler = signal.signal(signal.SIGALRM, handler)
             try:
-                signal.alarm(10)
+                signal.alarm(MAX_JOIN_TIME)
                 assert join() is None
             finally:
                 signal.alarm(0)
@@ -364,7 +365,7 @@ class TestLokyBackend:
         else:
             assert join() is None
 
-        join.assert_timing_almost_zero()
+        join.assert_timing_lower_than(MAX_JOIN_TIME)
 
         assert not p.is_alive()
         assert p not in self.active_children()


### PR DESCRIPTION
This should kill one of the remaining unstable test on macos on the CI.

/cc @jeremiedbb @glemaitre 