### PR TITLE
MNT drop py < 3.7 support in fork_exec

### DIFF
--- a/loky/backend/fork_exec.py
+++ b/loky/backend/fork_exec.py
@@ -7,23 +7,20 @@
 import os
 import sys
 
-if sys.platform == "darwin" and sys.version_info < (3, 3):
-    FileNotFoundError = OSError
-
 
 def close_fds(keep_fds):  # pragma: no cover
     """Close all the file descriptors except those in keep_fds."""
 
     # Make sure to keep stdout and stderr open for logging purpose
-    keep_fds = set(keep_fds).union([1, 2])
+    keep_fds = {*keep_fds, 1, 2}
 
     # We try to retrieve all the open fds
     try:
-        open_fds = set(int(fd) for fd in os.listdir('/proc/self/fd'))
+        open_fds = {int(fd) for fd in os.listdir('/proc/self/fd')}
     except FileNotFoundError:
         import resource
         max_nfds = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
-        open_fds = set(fd for fd in range(3, max_nfds))
+        open_fds = {fd for fd in range(3, max_nfds)}
         open_fds.add(0)
 
     for i in open_fds - keep_fds:


### PR DESCRIPTION
Part of #304 