### PR TITLE
MNT drop py < 3.7 support in backend init

### DIFF
--- a/loky/backend/__init__.py
+++ b/loky/backend/__init__.py
@@ -1,16 +1,15 @@
 import os
 import sys
+from multiprocessing import synchronize
 
 from .context import get_context
 
-if sys.version_info > (3, 4):
 
-    def _make_name():
-        name = f'/loky-{os.getpid()}-{next(synchronize.SemLock._rand)}'
-        return name
+def _make_name():
+    name = f'/loky-{os.getpid()}-{next(synchronize.SemLock._rand)}'
+    return name
 
-    # monkey patch the name creation for multiprocessing
-    from multiprocessing import synchronize
-    synchronize.SemLock._make_name = staticmethod(_make_name)
+# monkey patch the name creation for multiprocessing
+synchronize.SemLock._make_name = staticmethod(_make_name)
 
 __all__ = ["get_context"]


### PR DESCRIPTION
Part of #304