### PR TITLE
MNT drop py < 3.7 support in test_worker_timeout

### DIFF
--- a/tests/test_worker_timeout.py
+++ b/tests/test_worker_timeout.py
@@ -4,6 +4,7 @@ import pytest
 import threading
 import warnings
 import multiprocessing as mp
+
 from loky.backend import get_context
 from loky import ProcessPoolExecutor
 from loky import get_reusable_executor
@@ -11,7 +12,7 @@ from loky.backend.queues import SimpleQueue
 from loky.backend.reduction import dumps
 
 
-class SlowlyPickling(object):
+class SlowlyPickling:
     """Simulate slowly pickling object, e.g. large numpy array or dict"""
     def __init__(self, delay=1):
         self.delay = delay
@@ -23,7 +24,7 @@ class SlowlyPickling(object):
 
 class DelayedSimpleQueue(SimpleQueue):
     def __init__(self, reducers=None, ctx=None, delay=.1):
-        super(DelayedSimpleQueue, self).__init__(reducers=reducers, ctx=ctx)
+        super().__init__(reducers=reducers, ctx=ctx)
         self.out_queue = SimpleQueue(ctx=ctx)
         self._inner_reader = self._reader
         self._reader = self.out_queue._reader
@@ -64,7 +65,7 @@ class DelayedSimpleQueue(SimpleQueue):
         mp.util.debug("Defeeder clean exit")
 
 
-class TestTimeoutExecutor():
+class TestTimeoutExecutor:
     def test_worker_timeout_mock(self):
         timeout = .001
         context = get_context()
@@ -75,9 +76,9 @@ class TestTimeoutExecutor():
 
         with pytest.warns(UserWarning,
                           match=r'^A worker stopped while some jobs'):
-            for i in range(5):
+            for _ in range(5):
                 # Trigger worker spawn for lazy executor implementations
-                for result in executor.map(id, range(8)):
+                for _ in executor.map(id, range(8)):
                     pass
 
         executor.shutdown()
@@ -117,6 +118,6 @@ class TestTimeoutExecutor():
 
         # The warning detection is unreliable on pypy
         if not hasattr(sys, "pypy_version_info"):
-            assert len(record) > 0, "No warnings was emitted."
+            assert record, "No warnings was emitted."
             msg = record[0].message.args[0]
             assert 'A worker stopped while some jobs' in msg


### PR DESCRIPTION
Part of #304 