### PR TITLE
WIP make default resource_tracker ignore FileNotFoundError?

### DIFF
--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -47,6 +47,7 @@ import warnings
 import threading
 from _multiprocessing import sem_unlink
 from multiprocessing import util
+import contextlib
 
 from . import spawn
 
@@ -61,9 +62,20 @@ __all__ = ['ensure_running', 'register', 'unregister']
 _HAVE_SIGMASK = hasattr(signal, 'pthread_sigmask')
 _IGNORED_SIGNALS = (signal.SIGINT, signal.SIGTERM)
 
+
+def _rmtree_ignore_not_found(folderpath):
+    with contextlib.suppress(FileNotFoundError):
+        shutil.rmtree(folderpath)
+
+
+def _unlink_ignore_not_found(filepath):
+    with contextlib.suppress(FileNotFoundError):
+        os.unlink(filepath)
+
+
 _CLEANUP_FUNCS = {
-    'folder': shutil.rmtree,
-    'file': os.unlink
+    'folder': _rmtree_ignore_not_found,
+    'file': _unlink_ignore_not_found
 }
 
 if os.name == "posix":


### PR DESCRIPTION
I am wondering if we should just not make the resource tracker ignore `FileNotFoundError` by default for folders and files.

We have a test in joblib ([test_resource_tracker_silent_when_reference_cycles](https://github.com/joblib/joblib/blob/ea8562fdeda5c20ed059fdeeff83b1b4792dfa7a/joblib/test/test_memmapping.py#L683)) that is marked xfailed when the backend is joblib.

Not sure if this kind of situation should be dealt with specifically in joblib or more generally by default in loky. If we decide to do so, we to adapt the loky tests accordingly because the proposed change is breaking the assumption that and error should be raised.

Note that I have started to notice this kinds of warnings in the resource tracker also with the multiprocessing backend (with the PyPy CI worker), so maybe this should be changed in the upstream Python resource tracker config as well.