### PR TITLE
Put back import of Future from ._base

### DIFF
--- a/loky/__init__.py
+++ b/loky/__init__.py
@@ -12,9 +12,9 @@ from concurrent.futures import (
     ALL_COMPLETED,
     FIRST_COMPLETED,
     FIRST_EXCEPTION,
-    Future,
 )
 
+from ._base import Future
 from .backend.context import cpu_count
 from .backend.reduction import set_loky_pickler
 from .reusable_executor import get_reusable_executor

--- a/loky/_base.py
+++ b/loky/_base.py
@@ -19,6 +19,7 @@ from concurrent.futures import Future as _BaseFuture
 from concurrent.futures._base import LOGGER
 
 
+# TODO We should be able to directly use Future from concurrent.futures
 # To make loky._base.Future instances awaitable  by concurrent.futures.wait,
 # derive our custom Future class from _BaseFuture. _invoke_callback is the only
 # modification made to this class in loky.


### PR DESCRIPTION
mistake during the dropping of py < 3.7 support.