### PR TITLE
MAINT use plain text in subprocess

### DIFF
--- a/continuous_integration/install_coverage_subprocess_pth.py
+++ b/continuous_integration/install_coverage_subprocess_pth.py
@@ -5,12 +5,12 @@
 import os.path as op
 from distutils.sysconfig import get_python_lib
 
-FILE_CONTENT = u"""\
+FILE_CONTENT = """\
 import coverage; coverage.process_startup()
 """
 
 filename = op.join(get_python_lib(), 'coverage_subprocess.pth')
-with open(filename, 'wb') as f:
-    f.write(FILE_CONTENT.encode('ascii'))
+with open(filename, mode='w') as f:
+    f.write(FILE_CONTENT)
 
 print(f'Installed subprocess coverage support: {filename}')

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -172,22 +172,22 @@ def _count_physical_cores():
     try:
         if sys.platform == "linux":
             cpu_info = subprocess.run(
-                "lscpu --parse=core".split(" "), capture_output=True)
-            cpu_info = cpu_info.stdout.decode("utf-8").splitlines()
+                "lscpu --parse=core".split(" "), capture_output=True, text=True)
+            cpu_info = cpu_info.stdout.splitlines()
             cpu_info = {line for line in cpu_info if not line.startswith("#")}
             cpu_count_physical = len(cpu_info)
         elif sys.platform == "win32":
             cpu_info = subprocess.run(
                 "wmic CPU Get NumberOfCores /Format:csv".split(" "),
-                capture_output=True)
-            cpu_info = cpu_info.stdout.decode('utf-8').splitlines()
+                capture_output=True, text=True)
+            cpu_info = cpu_info.stdout.splitlines()
             cpu_info = [l.split(",")[1] for l in cpu_info
                         if (l and l != "Node,NumberOfCores")]
             cpu_count_physical = sum(map(int, cpu_info))
         elif sys.platform == "darwin":
             cpu_info = subprocess.run(
-                "sysctl -n hw.physicalcpu".split(" "), capture_output=True)
-            cpu_info = cpu_info.stdout.decode('utf-8')
+                "sysctl -n hw.physicalcpu".split(" "), capture_output=True, text=True)
+            cpu_info = cpu_info.stdout
             cpu_count_physical = int(cpu_info)
         else:
             raise NotImplementedError(

--- a/loky/backend/utils.py
+++ b/loky/backend/utils.py
@@ -81,18 +81,17 @@ def _recursive_terminate(pid):
         try:
             children_pids = subprocess.check_output(
                 ["pgrep", "-P", str(pid)],
-                stderr=None
+                stderr=None, text=True
             )
         except subprocess.CalledProcessError as e:
             # `ps` returns 1 when no child process has been found
             if e.returncode == 1:
-                children_pids = b''
+                children_pids = ''
             else:
                 raise
 
         # Decode the result, split the cpid and remove the trailing line
-        children_pids = children_pids.decode().split('\n')[:-1]
-        for cpid in children_pids:
+        for cpid in children_pids.splitlines():
             cpid = int(cpid)
             _recursive_terminate(cpid)
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     version=find_version(),
     description=("A robust implementation of "
                  "concurrent.futures.ProcessPoolExecutor"),
-    long_description=open('README.md', 'rb').read().decode('utf-8'),
+    long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     url='https://github.com/joblib/loky/',
     author='Thomas Moreau',

--- a/tests/_executor_mixin.py
+++ b/tests/_executor_mixin.py
@@ -46,12 +46,12 @@ def _direct_children_with_cmdline(p):
 def _running_children_with_cmdline(p):
     all_children = _direct_children_with_cmdline(p)
     workers = [(c, cmdline) for c, cmdline in all_children
-               if (u'semaphore_tracker' not in cmdline and
-                   u'resource_tracker' not in cmdline and
-                   u'multiprocessing.forkserver' not in cmdline)]
+               if ('semaphore_tracker' not in cmdline and
+                   'resource_tracker' not in cmdline and
+                   'multiprocessing.forkserver' not in cmdline)]
 
     forkservers = [c for c, cmdline in all_children
-                   if u'multiprocessing.forkserver' in cmdline]
+                   if 'multiprocessing.forkserver' in cmdline]
     for fs in forkservers:
         workers.extend(_direct_children_with_cmdline(fs))
     return workers

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -66,8 +66,8 @@ def sleep_and_return(delay, x):
 
 def sleep_and_write(t, filename, msg):
     time.sleep(t)
-    with open(filename, 'wb') as f:
-        f.write(str(msg).encode('utf-8'))
+    with open(filename, 'w') as f:
+        f.write(str(msg))
 
 
 class MyObject:

--- a/tests/test_cloudpickle_wrapper.py
+++ b/tests/test_cloudpickle_wrapper.py
@@ -64,8 +64,8 @@ class TestCloudpickleWrapper:
         try:
             fid, filename = mkstemp(suffix="_joblib.py")
             os.close(fid)
-            with open(filename, mode='wb') as f:
-                f.write(code.encode('ascii'))
+            with open(filename, mode='w') as f:
+                f.write(code)
             cmd += [filename]
             check_subprocess_call(cmd, stdout_regex=r'ok', timeout=10)
 
@@ -107,8 +107,8 @@ class TestCloudpickleWrapper:
         try:
             fid, filename = mkstemp(suffix="_joblib.py")
             os.close(fid)
-            with open(filename, mode='wb') as f:
-                f.write(code.encode('ascii'))
+            with open(filename, mode='w') as f:
+                f.write(code)
             cmd += [filename]
             check_subprocess_call(cmd, stdout_regex=r'ok', timeout=10)
         finally:
@@ -162,8 +162,8 @@ class TestCloudpickleWrapper:
         try:
             fid, filename = mkstemp(suffix="_joblib.py")
             os.close(fid)
-            with open(filename, mode='wb') as f:
-                f.write(code.encode('ascii'))
+            with open(filename, mode='w') as f:
+                f.write(code)
             cmd += [filename]
 
             env = {'LOKY_PICKLER': 'pickle'}
@@ -244,8 +244,8 @@ class TestCloudpickleWrapper:
         try:
             fid, filename = mkstemp(suffix="_joblib.py")
             os.close(fid)
-            with open(filename, mode='wb') as f:
-                f.write(code.encode('ascii'))
+            with open(filename, mode='w') as f:
+                f.write(code)
             cmd += [filename]
             if loky_pickler == "'pickle'":
                 match = r"(Can't get|has no) attribute 'test_func'"

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -460,10 +460,11 @@ class TestLokyBackend:
         """
         import subprocess
         try:
-            out = subprocess.check_output(["lsof", "-a", "-Fftn",
-                                           "-p", f"{pid}",
-                                           "-d", "^txt,^cwd,^rtd"])
-            lines = out.decode().split("\n")[1:-1]
+            out = subprocess.check_output(
+                f"lsof -a -Fftn -p {pid} -d ^txt,^cwd,^rtd".split(),
+                text=True,
+            )
+            lines = out.splitlines()[1:]
         except (FileNotFoundError, OSError):
             print("lsof does not exist on this platform. Skip open files"
                   "check.")
@@ -600,8 +601,8 @@ class TestLokyBackend:
             if run_file:
                 fid, filename = mkstemp(suffix="_joblib.py")
                 os.close(fid)
-                with open(filename, mode='wb') as f:
-                    f.write(code.encode('ascii'))
+                with open(filename, mode='w') as f:
+                    f.write(code)
                 cmd += [filename]
             else:
                 cmd += ["-c", code]
@@ -624,8 +625,8 @@ class TestLokyBackend:
         fid, filename = mkstemp(suffix="_joblib.py")
         os.close(fid)
         try:
-            with open(filename, mode='wb') as f:
-                f.write(code.encode('ascii'))
+            with open(filename, mode='w') as f:
+                f.write(code)
             stdout, stderr = check_subprocess_call([sys.executable, filename],
                                                    timeout=10)
             if sys.platform == "win32":
@@ -665,8 +666,8 @@ class TestLokyBackend:
         try:
             fid, filename = mkstemp(suffix="_joblib.py")
             os.close(fid)
-            with open(filename, mode='wb') as f:
-                f.write(code.encode('ascii'))
+            with open(filename, mode='w') as f:
+                f.write(code)
             check_subprocess_call([sys.executable, filename],
                                   stdout_regex=r'ok', timeout=10)
         finally:

--- a/tests/test_loky_module.py
+++ b/tests/test_loky_module.py
@@ -53,14 +53,15 @@ def test_cpu_count_affinity():
         pytest.skip()
 
     res = check_output([taskset_bin, '-c', '0',
-                        python_bin, '-c', cpu_count_cmd.format(args='')])
+                        python_bin, '-c', cpu_count_cmd.format(args='')],
+                       text=True)
 
     res_physical = check_output([
         taskset_bin, '-c', '0', python_bin, '-c',
-        cpu_count_cmd.format(args='only_physical_cores=True')])
+        cpu_count_cmd.format(args='only_physical_cores=True')], text=True)
 
-    assert res.strip().decode('utf-8') == '1'
-    assert res_physical.strip().decode('utf-8') == '1'
+    assert res.strip() == '1'
+    assert res_physical.strip() == '1'
 
 
 def test_cpu_count_cfs_limit():
@@ -84,10 +85,10 @@ def test_cpu_count_cfs_limit():
         f"{docker_bin} run --rm --cpus 0.5 -v {loky_project_path}:/loky python:3.7 "
         f"/bin/bash -c 'pip install --quiet -e /loky ; "
         f"python -c \"{cpu_count_cmd.format(args='')}\"'",
-        shell=True
+        shell=True, text=True
     )
 
-    assert res.strip().decode('utf-8') == '1'
+    assert res.strip() == '1'
 
 
 def test_only_physical_cores_error():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -125,7 +125,7 @@ def check_subprocess_call(cmd, timeout=1, stdout_regex=None,
         env = {**os.environ, **env}
 
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE, env=env)
+                            stderr=subprocess.PIPE, env=env, text=True)
 
     def kill_process():
         warnings.warn(f"Timeout running {cmd}")
@@ -136,7 +136,6 @@ def check_subprocess_call(cmd, timeout=1, stdout_regex=None,
         timer.start()
         stdout, stderr = proc.communicate()
 
-        stdout, stderr = stdout.decode(), stderr.decode()
         if proc.returncode == -9:
             message = (
                 f'Subprocess timeout after {timeout}s.\nStdout:\n{stdout}\n'
@@ -210,8 +209,8 @@ def check_python_subprocess_call(code, stdout_regex=None):
     try:
         fid, filename = mkstemp(suffix="_joblib.py")
         os.close(fid)
-        with open(filename, mode='wb') as f:
-            f.write(code.encode('ascii'))
+        with open(filename, mode='w') as f:
+            f.write(code)
         cmd += [filename]
         check_subprocess_call(cmd, stdout_regex=stdout_regex, timeout=10)
     finally:


### PR DESCRIPTION
Towards #304 

Uses python string instead of bytes.
Uses text in subprocess methods.