### PR TITLE
Make executor tests use fewer workers with PyPy

### DIFF
--- a/tests/_executor_mixin.py
+++ b/tests/_executor_mixin.py
@@ -18,6 +18,8 @@ except ImportError:
     psutil_exceptions = ()
 
 
+IS_PYPY = hasattr(sys, "pypy_version_info")
+
 # Set a large timeout as it should only be reached in case of deadlocks
 TIMEOUT = 40
 
@@ -122,7 +124,9 @@ def _check_executor_started(executor):
 
 
 class ExecutorMixin:
-    worker_count = 5
+    # PyPy is slower to create worker processes and creating
+    # too many processes can cause some tests to timeout.
+    worker_count = 2 if IS_PYPY else 5
 
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
This is a revival of #326 since `test_thread_safety` timeouted again on `master` after the merge of #348:

https://github.com/joblib/loky/runs/5181604501