### PR TITLE
Fix flaky test processes crash handling after executor gc

### DIFF
--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -215,7 +215,7 @@ class ExecutorShutdownTest:
             assert result == expected
 
         # Once all pending jobs have completed the executor and threads should
-        # terminate automatically. Note that the effictive time for Python
+        # terminate automatically. Note that the effective time for a Python
         # process to completely shutdown can vary a lot especially on loaded CI
         # machines with and the atexit callbacks that writes test coverage data
         # to disk. Let's be patient.
@@ -803,7 +803,7 @@ class ExecutorTest:
                 pass
 
             # Check that all workers shutdown (via timeout) when waiting a bit:
-            # note that the effictive time for Python process to completely
+            # note that the effective time for a Python process to completely
             # shutdown can vary a lot especially on loaded CI machines with and
             # the atexit callbacks that writes test coverage data to disk.
             # Let's be patient.

--- a/tests/test_synchronize.py
+++ b/tests/test_synchronize.py
@@ -48,7 +48,7 @@ def assert_sem_value_equal(sem, value):
 
 
 def assert_timing_almost_equal(t1, t2=0):
-    assert abs(t1 - t2) < 1e-1
+    assert abs(t1 - t2) < 2e-1
 
 
 class TestLock:


### PR DESCRIPTION
Hopefully fixes #338.

It's likely that #348 has already fixed the flaky `test_processes_crash_handling_after_executor_gc`
 observed in #338 because the executor is flagged as broken in this test and therefore the workers should now be SIGKILLed faster (at least on POSIX) but while reading the stderr trace of #338 to understand the race condition I suspect that this can also happen `test_processes_terminate_on_executor_gc` where the workers are terminated without a kill which can be slower than expected on an overloaded CI with coverage data dumped to disk.

Let's be rather safe than sorry.

https://twitter.com/Nick_Craver/status/1489421247381389312