### PR TITLE
Increase timeout in test_thread_safety for PyPy

### DIFF
--- a/continuous_integration/runtests.sh
+++ b/continuous_integration/runtests.sh
@@ -15,7 +15,7 @@ if [ "$JOBLIB_TESTS" = "true" ]; then
     which python
     git clone https://github.com/joblib/joblib.git src_joblib
     cd src_joblib
-    pip install pytest
+    pip install "pytest<7.0"  # Need to update remove occurrences of pytest.warns(None)
     pip install threadpoolctl  # required by some joblib tests
 
     pip install -e .

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -703,11 +703,11 @@ class ExecutorTest:
     # backported from the Python 3 concurrent.futures package.
     #
 
-    def _test_thread_safety(self, thread_idx, results):
+    def _test_thread_safety(self, thread_idx, results, timeout=30.):
         try:
             # submit a mix of very simple tasks with map and submit,
             # cancel some of them and check the results
-            map_future_1 = self.executor.map(sqrt, range(40), timeout=10)
+            map_future_1 = self.executor.map(sqrt, range(40), timeout=timeout)
             if thread_idx % 2 == 0:
                 # Make it more likely for scheduling threads to overtake one
                 # another
@@ -717,13 +717,13 @@ class ExecutorTest:
             for i, f in enumerate(submit_futures):
                 if i % 2 == 0:
                     f.cancel()
-            map_future_2 = self.executor.map(sqrt, range(40), timeout=10)
+            map_future_2 = self.executor.map(sqrt, range(40), timeout=timeout)
 
             assert list(map_future_1) == [sqrt(x) for x in range(40)]
             assert list(map_future_2) == [sqrt(i) for i in range(40)]
             for i, f in enumerate(submit_futures):
                 if i % 2 == 1 or not f.cancelled():
-                    assert f.result(timeout=30.) is None
+                    assert f.result(timeout=timeout) is None
             results[thread_idx] = 'ok'
         except Exception as e:
             # Ensure that py.test can report the content of the exception

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -723,11 +723,12 @@ class ExecutorTest:
             assert list(map_future_2) == [sqrt(i) for i in range(40)]
             for i, f in enumerate(submit_futures):
                 if i % 2 == 1 or not f.cancelled():
-                    assert f.result(timeout=10) is None
+                    assert f.result(timeout=30.) is None
             results[thread_idx] = 'ok'
-        except Exception:
+        except Exception as e:
             # Ensure that py.test can report the content of the exception
-            results[thread_idx] = traceback.format_exc()
+            # by raising it in the main test thread
+            results[thread_idx] = e
 
     def test_thread_safety(self):
         # Check that our process-pool executor can be shared to schedule work
@@ -741,8 +742,9 @@ class ExecutorTest:
         for t in threads:
             t.join()
         for result in results:
-            if result != "ok":
-                raise AssertionError(result)
+            if isinstance(result, Exception):
+                raise result
+            assert result == "ok"
 
     @classmethod
     def return_inputs(cls, *args):


### PR DESCRIPTION
Bumps the timeout to 30s (instead of 10s) as PyPy processes can be significantly slower to start-up than CPython, despite the recently merged #349. If it still fails, maybe there is a real deadlock and that would not be just a false positive of a too strict test.

Also: raise the timeout exception if it occurs instead of formatting the traceback as the message of an AssertionError.