### PR TITLE
Release 3.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-### 3.1.0 - XXXX-XX-XX
+### 3.1.0 - 2022-02-17
 
 - Fix loky.cpu_count() to properly detect the number of allowed CPUs based on
   the /sys/fs/cgroup/cpu.max file on newest Linux versions with cgroup v2.
@@ -12,6 +12,9 @@
 - Make `shutdown(kill_workers=True)` consistently use the SIGKILL
   signal on POSIX. Previously a mix of SIGKILL and SIGTERM was issued
   and could deadlock the shutdown process (#348 and #357).
+
+- Big code clean-up to drop support for older Python versions.
+  Python 3.7 or later is now required. (#304)
 
 ### 3.0.0 - 2021-09-10
 

--- a/loky/__init__.py
+++ b/loky/__init__.py
@@ -29,4 +29,4 @@ __all__ = ["get_reusable_executor", "cpu_count", "wait", "as_completed",
            "wrap_non_picklable_objects", "set_loky_pickler"]
 
 
-__version__ = '3.1.0.dev0'
+__version__ = '3.1.0'

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -1,6 +1,5 @@
 ###############################################################################
-# Basic context management with LokyContext and  provides
-# compat for UNIX 2.7 and 3.3
+# Basic context management with LokyContext
 #
 # author: Thomas Moreau and Olivier Grisel
 #
@@ -8,6 +7,7 @@
 #  * Create a context ensuring loky uses only objects that are compatible
 #  * Add LokyContext to the list of context of multiprocessing so loky can be
 #    used with multiprocessing.set_start_method
+#  * Implement a CFS-aware amd physical-core aware cpu_count function.
 #
 import os
 import sys
@@ -246,7 +246,8 @@ class LokyContext(BaseContext):
 
     if sys.platform != "win32":
         """For Unix platform, use our custom implementation of synchronize
-        relying on ctypes to interface with pthread semaphores.
+        ensuring that we use the loky.backend.resource_tracker to clean-up
+        the semaphores in case of a worker crash.
         """
         def Semaphore(self, value=1):
             """Returns a semaphore object"""

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -6,9 +6,13 @@
 #
 # adapted from multiprocessing/semaphore_tracker.py  (17/02/2017)
 #  * include custom spawnv_passfds to start the process
-#  * use custom unlink from our own SemLock implementation
 #  * add some VERBOSE logging
 #
+# TODO: multiprocessing.resource_tracker was contributed to Python 3.8 so
+# once loky drops support for Python 3.7 it might be possible to stop
+# maintaining this loky-specific fork. As a consequence, it might also be
+# possible to stop maintaining the loky.backend.synchronize fork of
+# multiprocessing.synchronize.
 
 #
 # On Unix we run a server process which keeps track of unlinked

--- a/loky/backend/synchronize.py
+++ b/loky/backend/synchronize.py
@@ -5,10 +5,12 @@
 #
 # adapted from multiprocessing/synchronize.py (17/02/2017)
 #  * Remove ctx argument for compatibility reason
-#  * Implementation of Condition/Event are necessary for compatibility
-#    with python2.7/3.3, Barrier should be reimplemented to for those
-#    version (but it is not used in loky).
+#  * Registers a cleanup function with the loky resource_tracker to remove the
+#    semaphore when the process dies instead.
 #
+# TODO: investigate which Python version is required to be able to use
+# multiprocessing.resource_tracker and therefore multiprocessing.synchronize
+# instead of a loky-specific fork.
 
 import os
 import sys

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -4,7 +4,6 @@
 # author: Thomas Moreau and Olivier Grisel
 #
 # adapted from concurrent/futures/process_pool_executor.py (17/02/2017)
-#  * Backport for python2.7/3.3,
 #  * Add an extra management thread to detect executor_manager_thread failures,
 #  * Improve the shutdown process to avoid deadlocks,
 #  * Add timeout for workers,


### PR DESCRIPTION
I took the opportunity of this PR to better document why we cannot remove the remaining multiprocessing backport files.

TL;DNR: we will probably be able to remove even more once we drop support for Python 3.7 since the resource tracker was contributed upstream in Python 3.8.