### PR TITLE
Use /sys/fs/cgroup/cpu.max for CPU quotas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 - Fix loky.cpu_count() to properly detect the number of allowed CPUs
   based on the /sys/fs/cgroup/cpu.max file when present. This
   makes it possible to respect docker/cgroup CFS quotas even when
-  /sys/fs/cgroup/cpu/cpu.cfs_quota_us is not present.
+  /sys/fs/cgroup/cpu/cpu.cfs_quota_us is not present (#355).
 
 - Fix an exception that could be raised in an auxiliary thread when
   garbage collecting an executor instance when shutting down the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ### 3.1.0 - XXXX-XX-XX
 
+- Fix loky.cpu_count() to properly detect the number of allowed CPUs
+  based on the /sys/fs/cgroup/cpu.max file when present. This
+  makes it possible to respect docker/cgroup CFS quotas even when
+  /sys/fs/cgroup/cpu/cpu.cfs_quota_us is not present.
+
 - Fix an exception that could be raised in an auxiliary thread when
   garbage collecting an executor instance when shutting down the
   the Python interpreter (#311).

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -131,16 +131,23 @@ def _cpu_count_user(os_cpu_count):
     # CFS scheduler CPU bandwidth limit
     # available in Linux since 2.6 kernel
     cpu_count_cfs = os_cpu_count
+    cpu_max_fname = "/sys/fs/cgroup/cpu.max"
     cfs_quota_fname = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
     cfs_period_fname = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
-    if os.path.exists(cfs_quota_fname) and os.path.exists(cfs_period_fname):
+    if os.path.exists(cpu_max_fname):
+        with open(cpu_max_fname) as fh:
+            cfs_quota_us, cfs_period_us = fh.read().strip().split(" ")
+            if cfs_quota_us == "max":
+                cfs_quota_us = cfs_period_us
+            cfs_quota_us, cfs_period_us = int(cfs_quota_us), int(cfs_period_us)
+    elif os.path.exists(cfs_quota_fname) and os.path.exists(cfs_period_fname):
         with open(cfs_quota_fname) as fh:
             cfs_quota_us = int(fh.read())
         with open(cfs_period_fname) as fh:
             cfs_period_us = int(fh.read())
 
-        if cfs_quota_us > 0 and cfs_period_us > 0:
-            cpu_count_cfs = math.ceil(cfs_quota_us / cfs_period_us)
+    if cfs_quota_us > 0 and cfs_period_us > 0:
+        cpu_count_cfs = math.ceil(cfs_quota_us / cfs_period_us)
 
     # User defined soft-limit passed as a loky specific environment variable.
     cpu_count_loky = int(os.environ.get('LOKY_MAX_CPU_COUNT', os_cpu_count))

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -153,7 +153,7 @@ def _cpu_count_user(os_cpu_count):
         cfs_quota_us = int(cfs_quota_us)
         cfs_period_us = int(cfs_period_us)
         if cfs_quota_us > 0 and cfs_period_us > 0:
-            cpu_count_cfs = math.ceil(int(cfs_quota_us) / int(cfs_period_us))
+            cpu_count_cfs = math.ceil(cfs_quota_us / cfs_period_us)
         else:
             # Meaningless quota config: just ignore (should never happen)
             cpu_count_cfs = os_cpu_count

--- a/tests/test_loky_module.py
+++ b/tests/test_loky_module.py
@@ -82,7 +82,7 @@ def test_cpu_count_cfs_limit():
     # We mount the loky source as /loky inside the container,
     # so it can be imported when running commands under /
 
-    # If tell docker to configure the CFS schedule to use 0.5 CPU, loky will
+    # Tell docker to configure the CFS schedule to use 0.5 CPU, loky will
     # always detect 1 CPU because it rounds up to the next integer.
     res_500_mCPU = int(check_output(
         f"{docker_bin} run --rm --cpus 0.5 -v {loky_project_path}:/loky python:3.7 "


### PR DESCRIPTION
Fixes #354.

Now `test_cpu_count_cfs_limit` passes locally on my macOS machine with a recent host Linux kernel in the docker VM.