### PR TITLE
Improve _kill_process_tree_without_psutil

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 
 - Make `shutdown(kill_workers=True)` consistently use the SIGKILL
   signal on POSIX. Previously a mix of SIGKILL and SIGTERM was issued
-  and could deadlock the shutdown process (#348).
+  and could deadlock the shutdown process (#348 and #357).
 
 ### 3.0.0 - 2021-09-10
 

--- a/loky/backend/utils.py
+++ b/loky/backend/utils.py
@@ -57,7 +57,7 @@ def _kill_process_tree_without_psutil(process):
             _windows_taskkill_process_tree(process.pid)
         else:
             _posix_recursive_kill(process.pid)
-    except Exception:
+    except Exception:  # pragma: no cover
         details = traceback.format_exc()
         warnings.warn(
             "Failed to kill subprocesses on this platform. Please install"
@@ -85,7 +85,7 @@ def _windows_taskkill_process_tree(pid):
         if e.returncode not in [128, 255]:
             # Let's raise to let the caller log the error details in a
             # warning and only kill the root process.
-            raise
+            raise  # pragma: no cover
 
 
 def _kill(pid):
@@ -101,7 +101,7 @@ def _kill(pid):
         # is already terminated, else, raise the error and let the top
         # level function raise a warning and retry to kill the process.
         if e.errno != errno.ESRCH:
-            raise
+            raise  # pragma: no cover
 
 
 def _posix_recursive_kill(pid):
@@ -115,7 +115,7 @@ def _posix_recursive_kill(pid):
         if e.returncode == 1:
             children_pids = ''
         else:
-            raise
+            raise  # pragma: no cover
 
     # Decode the result, split the cpid and remove the trailing line
     for cpid in children_pids.splitlines():

--- a/loky/backend/utils.py
+++ b/loky/backend/utils.py
@@ -5,6 +5,7 @@ import errno
 import signal
 import warnings
 import subprocess
+import traceback
 try:
     import psutil
 except ImportError:
@@ -51,39 +52,40 @@ def _kill_process_tree_with_psutil(process):
 
 def _kill_process_tree_without_psutil(process):
     """Terminate a process and its descendants."""
-    if sys.platform == "win32":
-        # On windows, the taskkill function with option `/T` terminate a given
-        # process pid and its children.
-        try:
-            subprocess.check_output(
-                ["taskkill", "/F", "/T", "/PID", str(process.pid)], stderr=None
-            )
-        except subprocess.CalledProcessError as e:
-            # In Windows, taskkill returns 1 for permission denied and 128, 255
-            # for no process found.
-            if e.returncode == 1:
-                # Try to terminate the process without its descendants if
-                # taskkill was denied permission. If this fails too, with an
-                # error different from process not found, let the top level
-                # function raise a warning and retry to kill the process.
-                process.terminate()
-            elif e.returncode in [128, 255]:
-                # Process not found: ignore.
-                pass
-            else:
-                raise
-    else:
-        try:
-            _recursive_kill_posix(process.pid)
-        except OSError:
-            warnings.warn(
-                "Failed to kill subprocesses on this platform. Please install"
-                "psutil: https://github.com/giampaolo/psutil"
-            )
-            # In case we cannot introspect the children, we fall back to only
-            # killing the main process.
-            process.kill()
+    try:
+        if sys.platform == "win32":
+            _windows_taskkill_process_tree(process.pid)
+        else:
+            _posix_recursive_kill(process.pid)
+    except Exception:
+        details = traceback.format_exc()
+        warnings.warn(
+            "Failed to kill subprocesses on this platform. Please install"
+            "psutil: https://github.com/giampaolo/psutil\n"
+            f"Details:\n{details}"
+        )
+        # In case we cannot introspect or kill the descendants, we fall back to
+        # only killing the main process.
+        #
+        # Note: on Windows, process.kill() is an alias for process.terminate()
+        # which in turns calls the Win32 API function TerminateProcess().
+        process.kill()
     process.join()
+
+
+def _windows_taskkill_process_tree(pid):
+    # On windows, the taskkill function with option `/T` terminate a given
+    # process pid and its children.
+    try:
+        subprocess.check_output(
+            ["taskkill", "/F", "/T", "/PID", str(pid)], stderr=None
+        )
+    except subprocess.CalledProcessError as e:
+        # In Windows, taskkill returns 128, 255 for no process found.
+        if e.returncode not in [128, 255]:
+            # Let's raise to let the caller log the error details in a
+            # warning and only kill the root process.
+            raise
 
 
 def _kill(pid):
@@ -102,7 +104,7 @@ def _kill(pid):
             raise
 
 
-def _recursive_kill_posix(pid):
+def _posix_recursive_kill(pid):
     """Recursively kill the descendants of a process before killing it."""
     try:
         children_pids = subprocess.check_output(
@@ -118,7 +120,7 @@ def _recursive_kill_posix(pid):
     # Decode the result, split the cpid and remove the trailing line
     for cpid in children_pids.splitlines():
         cpid = int(cpid)
-        _recursive_kill_posix(cpid)
+        _posix_recursive_kill(cpid)
 
     _kill(pid)
 


### PR DESCRIPTION
Fix #356.
Follow-up #348.

Make the windows and the posix variants more symmetric.

For both platform families, if the system-specific tree kill method fails for
any reason other than process not found, log a warning message with the
traceback and recommand the user to install psutil, and try to terminate the
the root process to avoid the stalled shutdown observed in #356 on Windows.