### PR TITLE
Rename CFS to Cgroup in cpu_count doc and local variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,9 @@
 ### 3.1.0 - XXXX-XX-XX
 
-- Fix loky.cpu_count() to properly detect the number of allowed CPUs
-  based on the /sys/fs/cgroup/cpu.max file when present. This
-  makes it possible to respect docker/cgroup CFS quotas even when
-  /sys/fs/cgroup/cpu/cpu.cfs_quota_us is not present (#355).
+- Fix loky.cpu_count() to properly detect the number of allowed CPUs based on
+  the /sys/fs/cgroup/cpu.max file on newest Linux versions with cgroup v2.
+  Fall-back to the /sys/fs/cgroup/cpu/cpu.cfs_quota_us file to keep on
+  supporting Linux versions that use cgroup v1 (#355 and #358).
 
 - Fix an exception that could be raised in an auxiliary thread when
   garbage collecting an executor instance when shutting down the

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -73,7 +73,7 @@ def cpu_count(only_physical_cores=False):
        ``multiprocessing.cpu_count``;
      * the CPU affinity settings of the current process
        (available on some Unix systems);
-     * CFS scheduler CPU bandwidth limit (available on Linux only, typically
+     * Cgroup CPU bandwidth limit (available on Linux only, typically
        set by docker and similar container orchestration systems);
      * the value of the LOKY_MAX_CPU_COUNT environment variable if defined.
     and is given as the minimum of these constraints.
@@ -81,7 +81,7 @@ def cpu_count(only_physical_cores=False):
     If ``only_physical_cores`` is True, return the number of physical cores
     instead of the number of logical cores (hyperthreading / SMT). Note that
     this option is not enforced if the number of usable cores is controlled in
-    any other way such as: process affinity, restricting CFS scheduler policy
+    any other way such as: process affinity, Cgroup restricted CPU bandwidth
     or the LOKY_MAX_CPU_COUNT environment variable. If the number of physical
     cores is not found, return the number of logical cores.
 
@@ -118,6 +118,42 @@ def cpu_count(only_physical_cores=False):
     return aggregate_cpu_count
 
 
+def _cpu_count_cgroup(os_cpu_count):
+    # Cgroup CPU bandwidth limit available in Linux since 2.6 kernel
+    cpu_max_fname = "/sys/fs/cgroup/cpu.max"
+    cfs_quota_fname = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+    cfs_period_fname = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+    if os.path.exists(cpu_max_fname):
+        # cgroup v2
+        # https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
+        with open(cpu_max_fname) as fh:
+            cpu_quota_us, cpu_period_us = fh.read().strip().split()
+    elif os.path.exists(cfs_quota_fname) and os.path.exists(cfs_period_fname):
+        # cgroup v1
+        # https://www.kernel.org/doc/html/latest/scheduler/sched-bwc.html#management
+        with open(cfs_quota_fname) as fh:
+            cpu_quota_us = fh.read().strip()
+        with open(cfs_period_fname) as fh:
+            cpu_period_us = fh.read().strip()
+    else:
+        # No Cgroup CPU bandwidth limit (e.g. non-Linux platform)
+        cpu_quota_us = "max"
+        cpu_period_us = 100_000  # unused, for consistency with default values
+
+    if cpu_quota_us == "max":
+        # No active Cgroup quota on a Cgroup-capable platform
+        return os_cpu_count
+    else:
+        cpu_quota_us = int(cpu_quota_us)
+        cpu_period_us = int(cpu_period_us)
+        if cpu_quota_us > 0 and cpu_period_us > 0:
+            return math.ceil(cpu_quota_us / cpu_period_us)
+        else:  # pragma: no cover
+            # Setting a negative cpu_quota_us value is a valid way to disable
+            # cgroup CPU bandwith limits
+            return os_cpu_count
+
+
 def _cpu_count_user(os_cpu_count):
     """Number of user defined available CPUs"""
     # Number of available CPUs given affinity settings
@@ -128,40 +164,12 @@ def _cpu_count_user(os_cpu_count):
         except NotImplementedError:
             pass
 
-    # CFS scheduler CPU bandwidth limit
-    # available in Linux since 2.6 kernel
-    cpu_max_fname = "/sys/fs/cgroup/cpu.max"
-    cfs_quota_fname = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
-    cfs_period_fname = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
-    if os.path.exists(cpu_max_fname):
-        with open(cpu_max_fname) as fh:
-            cfs_quota_us, cfs_period_us = fh.read().strip().split()
-    elif os.path.exists(cfs_quota_fname) and os.path.exists(cfs_period_fname):
-        with open(cfs_quota_fname) as fh:
-            cfs_quota_us = fh.read().strip()
-        with open(cfs_period_fname) as fh:
-            cfs_period_us = fh.read().strip()
-    else:
-        # No CFS scheduler CPU bandwidth limit (non-Linux or not enabled)
-        cfs_quota_us = "max"
-        cfs_period_us = 100_000  # unused, for consistency.
-
-    if cfs_quota_us == "max":
-        # No active CFS quota on a CFS-enabled platform
-        cpu_count_cfs = os_cpu_count
-    else:
-        cfs_quota_us = int(cfs_quota_us)
-        cfs_period_us = int(cfs_period_us)
-        if cfs_quota_us > 0 and cfs_period_us > 0:
-            cpu_count_cfs = math.ceil(cfs_quota_us / cfs_period_us)
-        else:
-            # Meaningless quota config: just ignore (should never happen)
-            cpu_count_cfs = os_cpu_count
+    cpu_count_cgroup = _cpu_count_cgroup(os_cpu_count)
 
     # User defined soft-limit passed as a loky specific environment variable.
     cpu_count_loky = int(os.environ.get('LOKY_MAX_CPU_COUNT', os_cpu_count))
 
-    return min(cpu_count_affinity, cpu_count_cfs, cpu_count_loky)
+    return min(cpu_count_affinity, cpu_count_cgroup, cpu_count_loky)
 
 
 def _count_physical_cores():

--- a/tests/test_loky_module.py
+++ b/tests/test_loky_module.py
@@ -64,7 +64,7 @@ def test_cpu_count_affinity():
     assert res_physical.strip() == '1'
 
 
-def test_cpu_count_cfs_limit():
+def test_cpu_count_cgroup_limit():
     if sys.platform == "win32":
         pytest.skip()
 
@@ -82,7 +82,7 @@ def test_cpu_count_cfs_limit():
     # We mount the loky source as /loky inside the container,
     # so it can be imported when running commands under /
 
-    # Tell docker to configure the CFS schedule to use 0.5 CPU, loky will
+    # Tell docker to configure the Cgroup quota to use 0.5 CPU, loky will
     # always detect 1 CPU because it rounds up to the next integer.
     res_500_mCPU = int(check_output(
         f"{docker_bin} run --rm --cpus 0.5 -v {loky_project_path}:/loky python:3.7 "
@@ -93,7 +93,7 @@ def test_cpu_count_cfs_limit():
     assert res_500_mCPU == 1
 
     # Limiting to 1.5 CPUs can lead to 1 if there is only 1 CPU on the machine or
-    # 2 if there are 2 CPU or more.
+    # 2 if there are 2 CPUs or more.
     res_1500_mCPU = int(check_output(
         f"{docker_bin} run --rm --cpus 1.5 -v {loky_project_path}:/loky python:3.7 "
         f"/bin/bash -c 'pip install --quiet -e /loky ; "


### PR DESCRIPTION
Follow-up on  #354.

- cgroup v2 does not refer to the name of a particular Linux  scheduler anymore;
- extract the Cgroup related logic in a dedicated helper function to make the code easier to follow and potentially use that helper function in isolation when debugging;
- added comment to make it explicit what is related to cgroup v1  what is related to cgroup v2;
- linked to the kernel.org doc;
- updated the docstring accordingly.