### PR TITLE
Fix a deadlock when a parent process is killed with SIGKILL

### DIFF
--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -409,9 +409,9 @@ def _process_worker(call_queue, result_queue, initializer, initargs,
             mp.util.debug('Exiting with code 1')
             sys.exit(1)
         if call_item is None:
-            # Notify queue management thread about clean worker shutdown
+            # Notify queue management thread about worker shutdown
             result_queue.put(pid)
-            is_clean = worker_exit_lock.acquire(True, timeout=timeout)
+            is_clean = worker_exit_lock.acquire(True, timeout=30)
             if is_clean:
                 mp.util.debug('Exited cleanly')
             else:

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -360,8 +360,8 @@ def _process_worker(call_queue, result_queue, initializer, initargs,
             to by the worker.
         initializer: A callable initializer, or None
         initargs: A tuple of args for the initializer
-        process_management_lock: A ctx.Lock avoiding worker timeout while some
-            workers are being spawned.
+        processes_management_lock: A ctx.Lock avoiding worker timeout while
+            some workers are being spawned.
         timeout: maximum time to wait for a new item in the call_queue. If that
             time is expired, the worker will shutdown.
         worker_exit_lock: Lock to avoid flagging the executor as broken on

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -411,9 +411,12 @@ def _process_worker(call_queue, result_queue, initializer, initargs,
         if call_item is None:
             # Notify queue management thread about clean worker shutdown
             result_queue.put(pid)
-            with worker_exit_lock:
+            is_clean = worker_exit_lock.acquire(True, timeout=timeout)
+            if is_clean:
                 mp.util.debug('Exited cleanly')
-                return
+            else:
+                mp.util.debug('Main process did not release worker_exit')
+            return
         try:
             r = call_item()
         except BaseException as e:

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -515,6 +515,7 @@ class TestTerminateExecutor(ReusableExecutorMixin):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
+                timeout=60
             )
             running_workers = []
             for line in out.stdout.split('\n'):

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -1,7 +1,9 @@
 import os
+import subprocess
 import sys
 import gc
 import ctypes
+from tempfile import NamedTemporaryFile
 import pytest
 import warnings
 import threading
@@ -485,6 +487,46 @@ class TestTerminateExecutor(ReusableExecutorMixin):
             executor.submit(gc.collect).result()
             for _ in executor.map(sleep, [.1] * 100):
                 pass
+
+    def test_sigkill_shutdown_leaks_workers(self):
+        # Create a parent process which will report its workers pids
+        # and sigkill itself.
+        code = """if True:
+        import os
+        import subprocess
+
+        import loky
+
+        parent_pid = os.getpid()
+        with loky.get_reusable_executor(timeout=5, kill_workers=True) as p:
+            list(p.map(lambda x: x, range(100)))
+            for pid in p._processes.keys():
+                print(f'worker_pid:{pid}')
+            print(f'parent_pid:{parent_pid}')
+            subprocess.check_call(f'kill -9 {parent_pid}', shell=True)
+        """
+        with NamedTemporaryFile(mode='w', suffix="_joblib.py",
+                                delete=True) as f:
+            f.write(code)
+            f.flush()
+            cmd = [sys.executable, f.name]
+            out = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            running_workers = []
+            for line in out.stdout.split('\n'):
+                if line.startswith('worker_pid'):
+                    worker_pid = int(line.split(':')[1])
+                    try:
+                        psutil.Process(worker_pid)
+                        running_workers.append(worker_pid)
+                    except psutil.NoSuchProcess:
+                        pass
+            assert not len(running_workers), (
+                f'There are running workers left: {running_workers}')
 
 
 class TestResizeExecutor(ReusableExecutorMixin):

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -493,17 +493,17 @@ class TestTerminateExecutor(ReusableExecutorMixin):
         # and sigkill itself.
         code = """if True:
         import os
-        import subprocess
 
         import loky
+        import psutil
 
         parent_pid = os.getpid()
-        with loky.get_reusable_executor(timeout=5, kill_workers=True) as p:
+        with loky.get_reusable_executor(timeout=1, kill_workers=True) as p:
             list(p.map(lambda x: x, range(100)))
             for pid in p._processes.keys():
                 print(f'worker_pid:{pid}')
             print(f'parent_pid:{parent_pid}')
-            subprocess.check_call(f'kill -9 {parent_pid}', shell=True)
+            psutil.Process(os.getpid()).kill()
         """
         with NamedTemporaryFile(mode='w', suffix="_joblib.py",
                                 delete=True) as f:


### PR DESCRIPTION
```python
#!/usr/bin/env python
import os
import subprocess

import loky

with loky.get_reusable_executor(timeout=10, kill_workers=True) as p:
    list(p.map(lambda x: x, range(1000)))
    subprocess.check_call(f'kill -9 {os.getpid()}', shell=True)
```
After the above process dies, there are `python -m loky.backend.popen_loky_posix --process-name LokyProcess-` processes left hanging for ever, causing memory leaks on the target server.

The real life scenario is getting SIGKILL (by OOM handler) and causing further memory leak.