### PR TITLE
Fix nested parallelism deadlock by calling _python_exit earlier when a worker is done

### DIFF
--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -68,7 +68,7 @@ import warnings
 import itertools
 import traceback
 import threading
-from time import time
+from time import time, sleep
 import multiprocessing as mp
 from functools import partial
 from pickle import PicklingError
@@ -412,10 +412,16 @@ def _process_worker(call_queue, result_queue, initializer, initargs,
             # Notify queue management thread about worker shutdown
             result_queue.put(pid)
             is_clean = worker_exit_lock.acquire(True, timeout=30)
+
+            # Early notify any loky executor running in this worker process
+            # (nested parallelism) that this process is about to shutdown to
+            # avoid a deadlock waiting undifinitely for the worker to finish.
+            _python_exit()
+
             if is_clean:
                 mp.util.debug('Exited cleanly')
             else:
-                mp.util.debug('Main process did not release worker_exit')
+                mp.util.info('Main process did not release worker_exit')
             return
         try:
             r = call_item()
@@ -779,21 +785,35 @@ class _ExecutorManagerThread(threading.Thread):
         with self.processes_management_lock:
             n_children_to_stop = 0
             for p in list(self.processes.values()):
+                mp.util.debug(f"releasing worker exit lock on {p.name}")
                 p._worker_exit_lock.release()
                 n_children_to_stop += 1
+
+        mp.util.debug(f"found {n_children_to_stop} processes to stop")
 
         # Send the right number of sentinels, to make sure all children are
         # properly terminated. Do it with a mechanism that avoid hanging on
         # Full queue when all workers have already been shutdown.
         n_sentinels_sent = 0
+        cooldown_time = 0.01
         while (n_sentinels_sent < n_children_to_stop
                 and self.get_n_children_alive() > 0):
             for _ in range(n_children_to_stop - n_sentinels_sent):
                 try:
                     self.call_queue.put_nowait(None)
                     n_sentinels_sent += 1
-                except queue.Full:
+                except queue.Full as e:
+                    if cooldown_time > 10.0:
+                        raise e
+                    mp.util.warning(
+                        "full call_queue prevented to send all sentinels at "
+                        "once, waiting..."
+                    )
+                    sleep(cooldown_time)
+                    cooldown_time *= 2
                     break
+
+        mp.util.debug(f"sent {n_sentinels_sent} sentinels to the call queue")
 
     def join_executor_internals(self):
         self.shutdown_workers()
@@ -817,12 +837,14 @@ class _ExecutorManagerThread(threading.Thread):
 
         # If .join() is not called on the created processes then
         # some ctx.Queue methods may deadlock on Mac OS X.
-        mp.util.debug("joining processes")
-        for p in list(self.processes.values()):
+        active_processes = list(self.processes.values())
+        mp.util.debug(f"joining {len(active_processes)} processes")
+        for p in active_processes:
+            mp.util.debug(f"joining process {p.name}")
             p.join()
 
         mp.util.debug("executor management thread clean shutdown of worker "
-                      f"processes: {list(self.processes)}")
+                      f"processes: {active_processes}")
 
     def get_n_children_alive(self):
         # This is an upper bound on the number of children alive.


### PR DESCRIPTION
Fix #363.

TODO:

- [ ] write a non-regression test in the loky test suite it-self.
- [ ] confirm that it fixes the skipped test cases in joblib: https://github.com/joblib/joblib/pull/1324
- [ ] check whether or not it fixes the stability / deadlocks observed on the macos CI of joblib.