### PR TITLE
TST test_error_in_nested_call_keeps_resource_tracker_silent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ### 3.3.0 - in development
 
-- TODO
+- Fix worker management logic in `get_reusable_executor` to ensure
+  the number of started worker process actually correspond to `max_workers`
+  when existing process concurrently time out (#370).
 
 ### 3.2.0 - 2022-09-14
 

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -924,7 +924,9 @@ class TestExecutorInitializer(ReusableExecutorMixin):
         for x in executor.map(self._test_initializer, delay=.1):
             assert x == 'uninitialized'
 
-    @pytest.mark.xfail(reason="https://github.com/joblib/loky/issues/369")
+    # XXX: not sure if #369 has been fixed or not. Let's not make it XFAIL
+    # for now to see if it is still flaky on CI.
+    # @pytest.mark.xfail(reason="https://github.com/joblib/loky/issues/369")
     def test_error_in_nested_call_keeps_resource_tracker_silent(self):
         # Safety smoke test: test that nested parallel calls don't yield noisy
         # resource_tracker outputs when the grandchild errors out.

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -924,6 +924,7 @@ class TestExecutorInitializer(ReusableExecutorMixin):
         for x in executor.map(self._test_initializer, delay=.1):
             assert x == 'uninitialized'
 
+    @pytest.mark.xfail(reason="https://github.com/joblib/loky/issues/369")
     def test_error_in_nested_call_keeps_resource_tracker_silent(self):
         # Safety smoke test: test that nested parallel calls don't yield noisy
         # resource_tracker outputs when the grandchild errors out.

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -923,3 +923,29 @@ class TestExecutorInitializer(ReusableExecutorMixin):
         executor = get_reusable_executor(max_workers=4)
         for x in executor.map(self._test_initializer, delay=.1):
             assert x == 'uninitialized'
+
+    def test_error_in_nested_call_keeps_resource_tracker_silent(self):
+        # Safety smoke test: test that nested parallel calls don't yield noisy
+        # resource_tracker outputs when the grandchild errors out.
+        cmd = '''if 1:
+            from loky import get_reusable_executor
+
+
+            def raise_error(i):
+                raise ValueError
+
+
+            def nested_loop(f):
+                executor = get_reusable_executor(max_workers=2)
+                list(executor.map(f, range(10))
+
+
+            executor = get_reusable_executor(max_workers=2)
+            list(executor.map(nested_loop, [raise_error])
+        '''
+        p = subprocess.Popen([sys.executable, '-c', cmd],
+                            stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        p.wait()
+        out, err = p.communicate()
+        assert p.returncode == 1, out.decode()
+        assert b"resource_tracker" not in err, err.decode()


### PR DESCRIPTION
Adapted reproducer for #369 to be part of the loky test suite.

Unfortunately I could never trigger the race condition locally so far.