### PR TITLE
ENH avoid spurious atexit outputs about thread wakeups for shutdown executors

### DIFF
--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -1199,6 +1199,7 @@ class ProcessPoolExecutor(Executor):
 
         if executor_manager_thread is not None and wait:
             executor_manager_thread.join()
+            _threads_wakeups.pop(executor_manager_thread, None)
 
         # To reduce the risk of opening too many files, remove references to
         # objects that use file descriptors.


### PR DESCRIPTION
Does not fix the performance problem on the PyPy CI but at least the logs are cleaner.