### PR TITLE
MAINT bump-up CI versions

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -19,7 +19,7 @@ jobs:
   strategy:
     matrix:
 
-      windows-py310:
+      windows-py311:
         imageName: windows-latest
         python.version: "3.11"
         tox.env: py311
@@ -28,7 +28,7 @@ jobs:
         python.version: "3.8"
         tox.env: py38
 
-      macos-py310:
+      macos-py311:
         imageName: "macos-latest"
         python.version: "3.11"
         tox.env: py311
@@ -43,7 +43,7 @@ jobs:
         tox.env: pypy3
         LOKY_MAX_CPU_COUNT: "2"
 
-      linux-py310:
+      linux-py311:
         imageName: "ubuntu-latest"
         python.version: "3.11"
         tox.env: py311

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -2,7 +2,7 @@ jobs:
 - job: linting
   displayName: Linting
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-latest
   steps:
     - task: UsePythonVersion@0
       inputs:
@@ -21,8 +21,8 @@ jobs:
 
       windows-py310:
         imageName: windows-latest
-        python.version: "3.10"
-        tox.env: py310
+        python.version: "3.11"
+        tox.env: py311
       windows-py37:
         imageName: windows-latest
         python.version: "3.8"
@@ -30,35 +30,35 @@ jobs:
 
       macos-py310:
         imageName: "macos-latest"
-        python.version: "3.10"
-        tox.env: py310
+        python.version: "3.11"
+        tox.env: py311
       macos-py37:
         imageName: "macos-latest"
-        python.version: "3.7"
-        tox.env: py37
+        python.version: "3.8"
+        tox.env: py38
 
       linux-pypy3:
-        imageName: "ubuntu-20.04"
+        imageName: "ubuntu-latest"
         python.version: "pypy3"
         tox.env: pypy3
         LOKY_MAX_CPU_COUNT: "2"
 
       linux-py310:
-        imageName: "ubuntu-20.04"
-        python.version: "3.10"
-        tox.env: py310
+        imageName: "ubuntu-latest"
+        python.version: "3.11"
+        tox.env: py311
       linux-py39-joblib-tests:
-        imageName: "ubuntu-20.04"
+        imageName: "ubuntu-latest"
         python.version: "3.9"
         tox.env: "py39"
         joblib.tests: "true"
       linux-python-py39-high-memory:
-        imageName: "ubuntu-20.04"
+        imageName: "ubuntu-latest"
         python.version: "3.9"
         tox.env: py39
         RUN_MEMORY: "true"
       linux-py38:
-        imageName: "ubuntu-20.04"
+        imageName: "ubuntu-latest"
         python.version: "3.8"
         tox.env: py38
 

--- a/loky/backend/synchronize.py
+++ b/loky/backend/synchronize.py
@@ -122,6 +122,8 @@ class SemLock:
         return self._semlock.release()
 
     def __getstate__(self):
+        if sys.platform == 'win32':
+            raise RuntimeError("Should only be used on posix platforms.")
         assert_spawning(self)
         sl = self._semlock
         h = sl.handle

--- a/loky/backend/synchronize.py
+++ b/loky/backend/synchronize.py
@@ -122,8 +122,6 @@ class SemLock:
         return self._semlock.release()
 
     def __getstate__(self):
-        if sys.platform == 'win32':
-            raise RuntimeError("Should only be used on posix platforms.")
         assert_spawning(self)
         sl = self._semlock
         h = sl.handle

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py37, py38, py39, py310, pypy3
+envlist = py38, py39, py310, py311, pypy3
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
Let's tests on more recent Python versions as well.

I removed CPython 3.7 from the matrix but we still test for Python 3.7 via PyPy. We would need to also bump it up but I think we can do that in a dedicated PyPy PR.

Note that testing with Python 3.11 might make the pytest orderning non-deterministic and might reveal old yet hidden bugs such as the one being investigated in #388.