### PR TITLE
FIX make sure max_workers cannot exceed 61 on windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 - Fix handling of CPU affinity  by using `psutil`'s `cpu_affinity` on platforms
   that do not implement `os.sched_getaffinity`, such as PyPy (#381).
 
+- Fix crash when using `max_workers > 61` on Windows. Loky will no longer
+  attempt to use more than 61 workers on that platform. (#390).
+
 ### 3.3.0 - 2022-09-15
 
 - Fix worker management logic in `get_reusable_executor` to ensure

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,8 @@
   that do not implement `os.sched_getaffinity`, such as PyPy (#381).
 
 - Fix crash when using `max_workers > 61` on Windows. Loky will no longer
-  attempt to use more than 61 workers on that platform. (#390).
+  attempt to use more than 61 workers on that platform (or 60 depending on the
+  Python version). (#390).
 
 ### 3.3.0 - 2022-09-15
 

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -21,11 +21,10 @@ from multiprocessing.context import BaseContext
 
 from .process import LokyProcess, LokyInitMainProcess
 
-try:
-    from concurrent.futures.process import _MAX_WINDOWS_WORKERS
-except ImportError:
-    # TODO: Remove backward compatibility with Python 3.7 once we drop support.
-    _MAX_WINDOWS_WORKERS = 61
+# Note: we do not directl use concurrent.futures.process._MAX_WINDOWS_WORKERS
+# because it can be 62 on older Python versions which would cause a crash with
+# loky.
+_MAX_WINDOWS_WORKERS = 61
 
 START_METHODS = ["loky", "loky_init_main", "spawn"]
 if sys.platform != "win32":

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -23,7 +23,7 @@ from concurrent.futures.process import _MAX_WINDOWS_WORKERS
 from .process import LokyProcess, LokyInitMainProcess
 
 # Apparently, on older Python versions, loky cannot work 61 workers on Windows
-# but instead 60.
+# but instead 60: ¯\_(ツ)_/¯
 if sys.version_info < (3, 10):
     _MAX_WINDOWS_WORKERS = _MAX_WINDOWS_WORKERS - 1
 

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -18,13 +18,10 @@ import warnings
 import multiprocessing as mp
 from multiprocessing import get_context as mp_get_context
 from multiprocessing.context import BaseContext
+from concurrent.futures.process import _MAX_WINDOWS_WORKERS
 
 from .process import LokyProcess, LokyInitMainProcess
 
-# Note: we do not directl use concurrent.futures.process._MAX_WINDOWS_WORKERS
-# because it can be 62 on older Python versions which would cause a crash with
-# loky.
-_MAX_WINDOWS_WORKERS = 61
 
 START_METHODS = ["loky", "loky_init_main", "spawn"]
 if sys.platform != "win32":

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -94,7 +94,8 @@ def cpu_count(only_physical_cores=False):
     or the LOKY_MAX_CPU_COUNT environment variable. If the number of physical
     cores is not found, return the number of logical cores.
 
-    Note that on Windows, the returned number of CPUs cannot exceed 61, see:
+    Note that on Windows, the returned number of CPUs cannot exceed 61 (or 60 for
+    Python < 3.10), see:
     https://bugs.python.org/issue26903.
 
     It is also always larger or equal to 1.

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -22,6 +22,10 @@ from concurrent.futures.process import _MAX_WINDOWS_WORKERS
 
 from .process import LokyProcess, LokyInitMainProcess
 
+# Apparently, on older Python versions, loky cannot work 61 workers on Windows
+# but instead 60.
+if sys.version_info < (3, 10):
+    _MAX_WINDOWS_WORKERS = _MAX_WINDOWS_WORKERS - 1
 
 START_METHODS = ["loky", "loky_init_main", "spawn"]
 if sys.platform != "win32":

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -79,7 +79,7 @@ from multiprocessing.connection import wait
 
 from ._base import Future
 from .backend import get_context
-from .backend.context import cpu_count
+from .backend.context import cpu_count, _MAX_WINDOWS_WORKERS
 from .backend.queues import Queue, SimpleQueue
 from .backend.reduction import set_loky_pickler, get_loky_pickler_name
 from .backend.utils import kill_process_tree, get_exitcodes_terminated_worker
@@ -1063,6 +1063,16 @@ class ProcessPoolExecutor(Executor):
             if max_workers <= 0:
                 raise ValueError("max_workers must be greater than 0")
             self._max_workers = max_workers
+
+        if (
+            sys.platform == "win32"
+            and self._max_workers > _MAX_WINDOWS_WORKERS
+        ):
+            warnings.warn(
+                f"On Windows, max_workers cannot exceed {_MAX_WINDOWS_WORKERS} "
+                "due to limitations in the Windows operating system."
+            )
+            self._max_workers = _MAX_WINDOWS_WORKERS
 
         if context is None:
             context = get_context()

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -1070,7 +1070,7 @@ class ProcessPoolExecutor(Executor):
         ):
             warnings.warn(
                 f"On Windows, max_workers cannot exceed {_MAX_WINDOWS_WORKERS} "
-                "due to limitations in the Windows operating system."
+                "due to limitations of the operating system."
             )
             self._max_workers = _MAX_WINDOWS_WORKERS
 

--- a/tests/test_loky_module.py
+++ b/tests/test_loky_module.py
@@ -10,7 +10,7 @@ import pytest
 
 import loky
 from loky import cpu_count
-from loky.backend.context import _cpu_count_user
+from loky.backend.context import _cpu_count_user, _MAX_WINDOWS_WORKERS
 
 
 def test_version():
@@ -32,6 +32,11 @@ def test_cpu_count():
     cpus_physical = cpu_count(only_physical_cores=True)
     assert type(cpus_physical) is int
     assert 1 <= cpus_physical <= cpus
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows specific test")
+def test_windows_max_cpu_count():
+    assert cpu_count() <= _MAX_WINDOWS_WORKERS
 
 
 cpu_count_cmd = (

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -1045,7 +1045,7 @@ def test_no_crash_max_workers_on_windows():
         )
         assert executor.submit(lambda: None).result() is None
 
-    # No warning on any OS when max_workers is does not exceed the limit.
+    # No warning on any OS when max_workers does not exceed the limit.
     assert len(record) == 0
     assert before_downsizing_executor is executor
     assert len(executor._processes) == _MAX_WINDOWS_WORKERS

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -1016,12 +1016,6 @@ class TestExecutorInitializer(ReusableExecutorMixin):
         assert b"resource_tracker" not in err, err.decode()
 
 
-# TODO: remove this test when we drop support for Python 3.7 which should be
-# the case before we release loky 3.4.0.
-# Life is too short to debug this on Python 3.7.
-@pytest.mark.skipif(
-    sys.version_info < (3, 8), reason="Still crashes on Python 3.7"
-)
 def test_no_crash_max_workers_on_windows():
     # Check that loky's reusable process pool executor does not crash when the
     # user asks for more workers than the maximum number of workers supported

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -1016,6 +1016,12 @@ class TestExecutorInitializer(ReusableExecutorMixin):
         assert b"resource_tracker" not in err, err.decode()
 
 
+# TODO: remove this test when we drop support for Python 3.7 which should be
+# the case before we release loky 3.4.0.
+# Life is too short to debug this on Python 3.7.
+@pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="Still crashes on Python 3.7"
+)
 def test_no_crash_max_workers_on_windows():
     # Check that loky's reusable process pool executor does not crash when the
     # user asks for more workers than the maximum number of workers supported


### PR DESCRIPTION
Fixes #192.

`loky.cpu_count` never returns more than 61 on Windows.

I the user explicitly ask for more than 61 workers on Windows, a warning is raised and `max_workers` is automatically set back to the 61 limit.

I added a new test that checks this by trying to spawn 62 workers. I ran the tests locally on windows and macos and it takes around 10-15s to run locally. I hope this will be ok on the CI, otherwise, I can disable it my default on (some) CI environments. Let's see.