### PR TITLE
ENH enable faulthandler traceback reporting on worker crash by SIGSEV

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ### 3.5.0 - in development
 
+- Automatically call `faulthandler.enable()` when starting loky worker
+  processes to report more informative information (post-mortem Python
+  tracebacks in particular) on worker crashs. (#419).
 
 - Fix detection of the number of physical cores in
   `cpu_count(only_physical_cores=True)` on some Linux systems and recent

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -114,7 +114,8 @@ class ExecutorShutdownTest:
         self.executor.shutdown()
         for i in range(30):
             with self.executor_type(max_workers=4) as e:
-                e.submit(id, ExitAtPickle())
+                with pytest.raises(PicklingError):
+                    e.submit(id, ExitAtPickle()).result()
 
     def test_interpreter_shutdown(self):
         # Free resources to avoid random timeout in CI

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -112,8 +112,9 @@ class ExecutorShutdownTest:
 
     def test_shutdown_with_sys_exit_at_pickle(self):
         self.executor.shutdown()
-        with self.executor_type(max_workers=4) as e:
-            e.submit(id, ExitAtPickle())
+        for i in range(30):
+            with self.executor_type(max_workers=4) as e:
+                e.submit(id, ExitAtPickle())
 
     def test_interpreter_shutdown(self):
         # Free resources to avoid random timeout in CI

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -993,13 +993,11 @@ log_to_stderr(logging.DEBUG)
             assert p.returncode == 1, out.decode()
             assert b"Current thread" in err, err.decode()
 
-        original_pythonfaulthandler_env = os.environ.get(
+        original_pythonfaulthandler_env = os.environ.pop(
             "PYTHONFAULTHANDLER", None
         )
         try:
             # Case 1: faulthandler should be automatically enabled by default.
-            if original_pythonfaulthandler_env is not None:
-                del os.environ["PYTHONFAULTHANDLER"]
             check_faulthandler_output(expect_enabled=True)
 
             # Case 2: faulthandler should also be enabled when
@@ -1019,8 +1017,7 @@ log_to_stderr(logging.DEBUG)
             )
         finally:
             if original_pythonfaulthandler_env is None:
-                os.environ["PYTHONFAULTHANDLER"] = "0"  # avoid KeyError
-                del os.environ["PYTHONFAULTHANDLER"]
+                os.environ.pop("PYTHONFAULTHANDLER", None)
             else:
                 os.environ["PYTHONFAULTHANDLER"] = (
                     original_pythonfaulthandler_env

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -953,10 +953,6 @@ class TestGetReusableExecutor(ReusableExecutorMixin):
         cmd = """if 1:
             from loky import get_reusable_executor
             import faulthandler
-            import logging
-            from multiprocessing.util import log_to_stderr
-
-            log_to_stderr(logging.DEBUG)
 
             def f(i):
                 if {expect_enabled}:

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -1026,9 +1026,9 @@ class TestGetReusableExecutor(ReusableExecutorMixin):
                 os.environ["PYTHONFAULTHANDLER"] = "0"  # avoid KeyError
                 del os.environ["PYTHONFAULTHANDLER"]
             else:
-                os.environ[
-                    "PYTHONFAULTHANDLER"
-                ] = original_pythonfaulthandler_env
+                os.environ["PYTHONFAULTHANDLER"] = (
+                    original_pythonfaulthandler_env
+                )
 
 
 class TestExecutorInitializer(ReusableExecutorMixin):


### PR DESCRIPTION
Automatically call `faulthandler.enable()` by default to dump extra debug info to crashed workers' stderr, typically on SIGSEV, SIGBUS and co.

I also expanded the error message of `TerminatedWorkerError` to point the users to look at stderr for more details. This should help us debug stability problems on our CI but also assist our users and interact more productively with them when they report problems.