### PR TITLE
CI First workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: CI
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+
+  linting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install black
+        run: |
+          pip install black==25.1.0
+      - name: Run black
+        run: |
+          black --check --diff .

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # General ignore rules
 .*
+!.github
 *sublime*
 tags
 


### PR DESCRIPTION
In https://github.com/joblib/loky/pull/430, the introduction of a first workflow doesn't run on the PR. It seems that it has to already be on master (or at least that at least 1 workflow already exist on master ? I don't know).

So I've been testing it on my fork and it seems to work, see https://github.com/jeremiedbb/loky/pull/1. But It's not complete. For instance it doesn't check the coverage.

So I propose to merge a very small subset (i.e. just the linting part) which has been tested on my fork and should be pretty safe first so that we have the workflow on master. Then I can keep working on https://github.com/joblib/loky/pull/430, to make sure that everything is fine, including the coverage for instance, directly on the main repo.