### PR TITLE
More informative assertion errors on unexpected warnings

### DIFF
--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -263,7 +263,7 @@ class TestResourceTracker:
                     the_warn.message
                 )
             else:
-                assert len(all_warn) == 0
+                assert len(all_warn) == 0, [w.message for w in all_warn]
 
     @pytest.mark.skipif(
         sys.platform == "win32", reason="Limited signal support on Windows"

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -1052,7 +1052,7 @@ def test_no_crash_max_workers_on_windows():
         assert executor.submit(lambda: None).result() is None
 
     # No warning on any OS when max_workers does not exceed the limit.
-    assert len(record) == 0
+    assert len(record) == 0, [w.message for w in record]
     assert before_downsizing_executor is executor
     assert len(executor._processes) == _MAX_WINDOWS_WORKERS
 


### PR DESCRIPTION
To make it easier to debug the cause of warnings that are randomly occurring on CI runs but not on local machines.