### PR TITLE
CI Add Python 3.13 jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,20 +46,23 @@ jobs:
       matrix:
         include:
 
-          - name: windows-py311
+          - name: windows-py313
             os: windows-latest
-            PYTHON_VERSION: "3.11"
+            PYTHON_VERSION: "3.13"
           - name: windows-py39
             os: windows-latest
             PYTHON_VERSION: "3.9"
 
-          - name: macos-py311
+          - name: macos-py313
             os: macos-latest
-            PYTHON_VERSION: "3.11"
+            PYTHON_VERSION: "3.13"
           - name: macos-py39
             os: macos-latest
             PYTHON_VERSION: "3.9"
 
+          - name: linux-py313
+            os: ubuntu-latest
+            PYTHON_VERSION: "3.13"
           - name: linux-py311
             os: ubuntu-latest
             PYTHON_VERSION: "3.11"

--- a/continuous_integration/install_coverage_subprocess_pth.py
+++ b/continuous_integration/install_coverage_subprocess_pth.py
@@ -3,13 +3,13 @@
 # http://coverage.readthedocs.io/en/latest/subprocess.html
 
 import os.path as op
-from distutils.sysconfig import get_python_lib
+from sysconfig import get_path
 
 FILE_CONTENT = """\
 import coverage; coverage.process_startup()
 """
 
-filename = op.join(get_python_lib(), "coverage_subprocess.pth")
+filename = op.join(get_path("platlib"), "coverage_subprocess.pth")
 with open(filename, mode="w") as f:
     f.write(FILE_CONTENT)
 

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering",
         "Topic :: Utilities",
         "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
I replaced the py311 jobs by py313 jobs on macos and windows to avoid growing the total number of jobs. However I added the py313 job for linux while keeping the py311 one. I figured we might want to test on more than 2 python versions, but I can remove the py311 job if you prefer.