### PR TITLE
MAINT typo in the codecov step of the GHA config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload to Codecov
         # always upload coverage even if tests fail
-        if: ${{ matrix.SKLEARN_TESTS != 'true' && (success() || failure()) }}
+        if: ${{ matrix.JOBLIB_TESTS != 'true' && (success() || failure()) }}
         uses: codecov/codecov-action@v5
         with:
           files: coverage.xml


### PR DESCRIPTION
I could not find any reference of `SKLEARN_TESTS` in the repo.