### PR TITLE
MNT Replace azure-pipelines badge by github actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ alt="Loky logo" width=96/></a>
 
 
 # Reusable Process Pool Executor
-[![Build Status](https://dev.azure.com/joblib/loky/_apis/build/status/joblib.loky?branchName=master)](https://dev.azure.com/joblib/loky/_build/latest?definitionId=2&branchName=master)
+[![Build Status](https://github.com/joblib/loky/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/joblib/loky/actions/workflows/test.yml?query=branch%3Amaster)
 [![Documentation Status](https://readthedocs.org/projects/loky/badge/?version=latest)](https://loky.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/joblib/loky/branch/master/graph/badge.svg)](https://codecov.io/gh/joblib/loky)
 [![DOI](https://zenodo.org/badge/48578152.svg)](https://zenodo.org/badge/latestdoi/48578152)


### PR DESCRIPTION
Forgot to do that as part of the migration to gh actions.