### PR TITLE
FIX support for frozen executables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,18 @@ jobs:
             # Do not install psutil on Python 3.9 to have some CI runs that
             # tests that loky has no hard dependency on psutil.
             NO_PSUTIL: "true"
+          - name: windows-py313-pyinstaller
+            os: windows-latest
+            PYTHON_VERSION: "3.13"
+            PYINSTALLER_TESTS: "true"
+          - name: macos-py313-pyinstaller
+            os: macos-latest
+            PYTHON_VERSION: "3.13"
+            PYINSTALLER_TESTS: "true"
+          - name: linux-py313-pyinstaller
+            os: ubuntu-latest
+            PYTHON_VERSION: "3.13"
+            PYINSTALLER_TESTS: "true"
 
     env: ${{ matrix }}
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -31,6 +31,10 @@ if [[ -z "$NO_PSUTIL" ]]; then
     PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES psutil"
 fi
 
+if [[ "$PYINSTALLER_TESTS" == "true" ]]; then
+    PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES pyinstaller"
+fi
+
 pip install $PIP_INSTALL_PACKAGES
 
 pip install -v .

--- a/continuous_integration/runtests.sh
+++ b/continuous_integration/runtests.sh
@@ -28,6 +28,9 @@ if [[ "$JOBLIB_TESTS" == "true" ]]; then
     cp "$LOKY_PATH"/continuous_integration/copy_loky.sh $JOBLIB/externals
     (cd $JOBLIB/externals && bash copy_loky.sh "$LOKY_PATH")
     pytest -vl --ignore $JOBLIB/externals --pyargs joblib
+elif [[ "$PYINSTALLER_TESTS" == "true" ]]; then
+    PYTEST_ARGS="-vl --timeout=300 --maxfail=1 --cov=loky --cov-report xml"
+    pytest $PYTEST_ARGS tests/test_loky_module.py -k freeze
 else
     # Make sure that we have the python docker image cached locally to avoid
     # a timeout in a test that needs it.

--- a/loky/__init__.py
+++ b/loky/__init__.py
@@ -17,15 +17,16 @@ from concurrent.futures import (
 
 from ._base import Future
 from .backend.context import cpu_count
+from .backend.spawn import freeze_support
 from .backend.reduction import set_loky_pickler
 from .reusable_executor import get_reusable_executor
 from .cloudpickle_wrapper import wrap_non_picklable_objects
 from .process_executor import BrokenProcessPool, ProcessPoolExecutor
 
-
 __all__ = [
     "get_reusable_executor",
     "cpu_count",
+    "freeze_support",
     "wait",
     "as_completed",
     "Future",

--- a/loky/backend/popen_loky_posix.py
+++ b/loky/backend/popen_loky_posix.py
@@ -14,7 +14,6 @@ from multiprocessing.context import set_spawning_popen
 
 from . import reduction, resource_tracker, spawn
 
-
 __all__ = ["Popen"]
 
 
@@ -112,10 +111,11 @@ class Popen:
             # for fd in self._fds:
             #     _mk_inheritable(fd)
 
-            cmd_python = [sys.executable]
-            cmd_python += ["-m", self.__module__]
-            cmd_python += ["--process-name", str(process_obj.name)]
-            cmd_python += ["--pipe", str(reduction._mk_inheritable(child_r))]
+            cmd_python = spawn.get_command_line(
+                self.__module__,
+                pipe_handle=reduction._mk_inheritable(child_r),
+                process_name=process_obj.name,
+            )
             reduction._mk_inheritable(child_w)
             reduction._mk_inheritable(tracker_fd)
             self._fds += [child_r, child_w, tracker_fd]
@@ -149,6 +149,32 @@ class Popen:
         return True
 
 
+def main(pipe_handle, process_name=None):
+    pipe_handle = int(pipe_handle)
+    exitcode = 1
+    try:
+        with os.fdopen(pipe_handle, "rb") as from_parent:
+            process.current_process()._inheriting = True
+            try:
+                prep_data = pickle.load(from_parent)
+                spawn.prepare(prep_data)
+                process_obj = pickle.load(from_parent)
+            finally:
+                del process.current_process()._inheriting
+
+        exitcode = process_obj._bootstrap()
+    except Exception:
+        print("\n\n" + "-" * 80)
+        print(f"{process_name} failed with traceback: ")
+        print("-" * 80)
+        import traceback
+
+        print(traceback.format_exc())
+        print("\n" + "-" * 80)
+
+    return exitcode
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -164,30 +190,4 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-
-    info = {}
-    exitcode = 1
-    try:
-        with os.fdopen(args.pipe, "rb") as from_parent:
-            process.current_process()._inheriting = True
-            try:
-                prep_data = pickle.load(from_parent)
-                spawn.prepare(prep_data)
-                process_obj = pickle.load(from_parent)
-            finally:
-                del process.current_process()._inheriting
-
-        exitcode = process_obj._bootstrap()
-    except Exception:
-        print("\n\n" + "-" * 80)
-        print(f"{args.process_name} failed with traceback: ")
-        print("-" * 80)
-        import traceback
-
-        print(traceback.format_exc())
-        print("\n" + "-" * 80)
-    finally:
-        if from_parent is not None:
-            from_parent.close()
-
-        sys.exit(exitcode)
+    sys.exit(main(args.pipe, args.process_name))

--- a/loky/backend/popen_loky_win32.py
+++ b/loky/backend/popen_loky_win32.py
@@ -9,7 +9,6 @@ from multiprocessing.popen_spawn_win32 import Popen as _Popen
 
 from . import reduction, spawn
 
-
 __all__ = ["Popen"]
 
 #
@@ -65,16 +64,24 @@ class Popen(_Popen):
         # terminated before it could steal the handle from the parent process.
         rhandle, whandle = _winapi.CreatePipe(None, 0)
         wfd = msvcrt.open_osfhandle(whandle, 0)
-        cmd = get_command_line(parent_pid=os.getpid(), pipe_handle=rhandle)
-
-        python_exe = spawn.get_executable()
+        cmd = spawn.get_command_line(
+            self.__module__,
+            extra_args=("--multiprocessing-fork",),
+            parent_pid=os.getpid(),
+            pipe_handle=rhandle,
+        )
+        python_exe = cmd[0]
 
         # copy the environment variables to set in the child process
         child_env = {**os.environ, **process_obj.env}
 
         # bpo-35797: When running in a venv, we bypass the redirect
         # executor and launch our base Python.
-        if WINENV and _path_eq(python_exe, sys.executable):
+        if (
+            not getattr(sys, "frozen", False)
+            and WINENV
+            and _path_eq(python_exe, sys.executable)
+        ):
             cmd[0] = python_exe = sys._base_executable
             child_env["__PYVENV_LAUNCHER__"] = sys.executable
 
@@ -117,25 +124,6 @@ class Popen(_Popen):
                 set_spawning_popen(None)
 
 
-def get_command_line(pipe_handle, parent_pid, **kwds):
-    """Returns prefix of command line used for spawning a child process."""
-    if getattr(sys, "frozen", False):
-        return [sys.executable, "--multiprocessing-fork", pipe_handle]
-    else:
-        prog = (
-            "from loky.backend.popen_loky_win32 import main; "
-            f"main(pipe_handle={pipe_handle}, parent_pid={parent_pid})"
-        )
-        opts = util._args_from_interpreter_flags()
-        return [
-            spawn.get_executable(),
-            *opts,
-            "-c",
-            prog,
-            "--multiprocessing-fork",
-        ]
-
-
 def is_forking(argv):
     """Return whether commandline indicates we are forking."""
     if len(argv) >= 2 and argv[1] == "--multiprocessing-fork":
@@ -146,7 +134,13 @@ def is_forking(argv):
 
 def main(pipe_handle, parent_pid=None):
     """Run code specified by data received over pipe."""
-    assert is_forking(sys.argv), "Not forking"
+    assert is_forking(sys.argv) or spawn._is_loky_forking(
+        sys.argv
+    ), "Not forking"
+
+    pipe_handle = int(pipe_handle)
+    if parent_pid is not None:
+        parent_pid = int(parent_pid)
 
     if parent_pid is not None:
         source_process = _winapi.OpenProcess(

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -106,6 +106,10 @@ class ResourceTracker(_ResourceTracker):
     function, which is run in a dedicated process.
     """
 
+    def __init__(self):
+        super().__init__()
+        self._read_handle = None
+
     def maybe_unlink(self, name, rtype):
         """Decrement the refcount of a resource, and delete it if it hits 0"""
         self._send("MAYBE_UNLINK", name, rtype)
@@ -128,6 +132,7 @@ class ResourceTracker(_ResourceTracker):
         # At this point, the resource_tracker process has been killed
         # or crashed.
         os.close(self._fd)
+        self._close_read_handle()
 
         # Let's remove the process entry from the process table on POSIX system
         # to avoid zombie processes.
@@ -148,10 +153,30 @@ class ResourceTracker(_ResourceTracker):
             "Some folders/semaphores might leak."
         )
 
+    def _close_read_handle(self):
+        if sys.platform != "win32" or self._read_handle is None:
+            return
+
+        try:
+            _winapi.CloseHandle(self._read_handle)
+        except OSError:
+            pass
+        finally:
+            self._read_handle = None
+
+    def _stop(self, *args, **kwargs):
+        try:
+            return super()._stop(*args, **kwargs)
+        finally:
+            self._close_read_handle()
+
     def _launch(self):
         # This is the overridden part of the resource tracker, which launches
         # loky's version, which is compatible with windows and allow to track
         # folders with external ref counting.
+
+        if sys.platform == "win32":
+            return self._launch_win32()
 
         fds_to_pass = []
         try:
@@ -159,19 +184,14 @@ class ResourceTracker(_ResourceTracker):
         except Exception:
             pass
 
-        # Create a pipe for posix and windows
         r, w = os.pipe()
-        if sys.platform == "win32":
-            _r = duplicate(msvcrt.get_osfhandle(r), inheritable=True)
-            os.close(r)
-            r = _r
 
-        cmd = f"from {main.__module__} import main; main({r}, {VERBOSE})"
+        args = spawn.get_command_line(
+            main.__module__, fd=r, verbose=int(VERBOSE)
+        )
         try:
             fds_to_pass.append(r)
             # process will out live us, so no need to wait on pid
-            exe = spawn.get_executable()
-            args = [exe, *util._args_from_interpreter_flags(), "-c", cmd]
             util.debug(f"launching resource tracker: {args}")
             # bpo-33613: Register a signal mask that will block the
             # signals.  This signal mask will be inherited by the child
@@ -182,7 +202,7 @@ class ResourceTracker(_ResourceTracker):
             try:
                 if _HAVE_SIGMASK:
                     signal.pthread_sigmask(signal.SIG_BLOCK, _IGNORED_SIGNALS)
-                pid = spawnv_passfds(exe, args, fds_to_pass)
+                pid = _spawn_resource_tracker(args[0], args, fds_to_pass)
             finally:
                 if _HAVE_SIGMASK:
                     signal.pthread_sigmask(
@@ -195,10 +215,37 @@ class ResourceTracker(_ResourceTracker):
             self._fd = w
             self._pid = pid
         finally:
-            if sys.platform == "win32":
-                _winapi.CloseHandle(r)
-            else:
-                os.close(r)
+            os.close(r)
+
+    def _launch_win32(self):
+        self._close_read_handle()
+        rhandle = whandle = None
+        w = None
+        try:
+            rhandle, whandle = _winapi.CreatePipe(None, 0)
+            w = msvcrt.open_osfhandle(whandle, 0)
+            whandle = None
+
+            args = spawn.get_command_line(
+                main.__module__,
+                pipe_handle=rhandle,
+                parent_pid=os.getpid(),
+                verbose=int(VERBOSE),
+            )
+            util.debug(f"launching resource tracker: {args}")
+            pid = _spawn_resource_tracker(args[0], args)
+        except BaseException:
+            if w is not None:
+                os.close(w)
+            if whandle is not None:
+                _winapi.CloseHandle(whandle)
+            if rhandle is not None:
+                _winapi.CloseHandle(rhandle)
+            raise
+        else:
+            self._fd = w
+            self._pid = pid
+            self._read_handle = rhandle
 
     def _ensure_running_and_write(self, msg=None):
         """Make sure that resource tracker process is running.
@@ -254,8 +301,29 @@ unregister = _resource_tracker.unregister
 getfd = _resource_tracker.getfd
 
 
-def main(fd, verbose=0):
+def main(fd=None, verbose=0, pipe_handle=None, parent_pid=None):
     """Run resource tracker."""
+    verbose = int(verbose)
+    if sys.platform == "win32":
+        if pipe_handle is None:
+            pipe_handle = fd
+        pipe_handle = int(pipe_handle)
+        if parent_pid is None:
+            fd = msvcrt.open_osfhandle(pipe_handle, os.O_RDONLY)
+        else:
+            source_process = _winapi.OpenProcess(
+                _winapi.SYNCHRONIZE | _winapi.PROCESS_DUP_HANDLE,
+                False,
+                int(parent_pid),
+            )
+            try:
+                handle = duplicate(pipe_handle, source_process=source_process)
+            finally:
+                _winapi.CloseHandle(source_process)
+            fd = msvcrt.open_osfhandle(handle, os.O_RDONLY)
+    else:
+        fd = int(fd)
+
     if verbose:
         util.log_to_stderr(level=util.DEBUG)
 
@@ -278,8 +346,6 @@ def main(fd, verbose=0):
     registry = {rtype: {} for rtype in _CLEANUP_FUNCS.keys()}
 
     try:
-        if sys.platform == "win32":
-            fd = msvcrt.open_osfhandle(fd, os.O_RDONLY)
         # keep track of registered/unregistered resources
         with open(fd, "rb") as f:
             for line in f:
@@ -393,19 +459,15 @@ def main(fd, verbose=0):
         util.debug("resource tracker shut down")
 
 
-def spawnv_passfds(path, args, passfds):
+def _spawn_resource_tracker(path, args, passfds=()):
     if sys.platform != "win32":
         args = [arg.encode("utf-8") for arg in args]
         path = path.encode("utf-8")
         return util.spawnv_passfds(path, args, passfds)
-    else:
-        passfds = sorted(passfds)
-        cmd = " ".join(f'"{x}"' for x in args)
-        try:
-            _, ht, pid, _ = _winapi.CreateProcess(
-                path, cmd, None, None, True, 0, None, None, None
-            )
-            _winapi.CloseHandle(ht)
-        except BaseException:
-            pass
-        return pid
+
+    cmd = " ".join(f'"{x}"' for x in args)
+    _, ht, pid, _ = _winapi.CreateProcess(
+        path, cmd, None, None, False, 0, None, None, None
+    )
+    _winapi.CloseHandle(ht)
+    return pid

--- a/loky/backend/spawn.py
+++ b/loky/backend/spawn.py
@@ -11,7 +11,12 @@ import sys
 import runpy
 import textwrap
 import types
+import ast
+import importlib
 from multiprocessing import process, util
+from multiprocessing import freeze_support as mp_freeze_support
+
+LOKY_FORK_MARKER = "--loky-fork"
 
 
 if sys.platform != "win32":
@@ -34,11 +39,65 @@ def get_executable():
     return _python_exe
 
 
+def _format_arg(name, value):
+    return f"{name}={value!r}"
+
+
+def _parse_arg(arg):
+    name, value = arg.split("=", 1)
+    try:
+        return name, ast.literal_eval(value)
+    except (SyntaxError, ValueError):
+        return name, value
+
+
+def _is_loky_forking(argv):
+    return len(argv) >= 3 and argv[1] == LOKY_FORK_MARKER
+
+
+def get_command_line(main_module, *, extra_args=(), **kwargs):
+    """
+    Returns a command line used for spawning a child process.
+    This command provides supports for frozen executables and
+    only works with a module exposing a main function.
+    """
+    if getattr(sys, "frozen", False):
+        return [
+            sys.executable,
+            LOKY_FORK_MARKER,
+            main_module,
+            *[_format_arg(name, value) for name, value in kwargs.items()],
+        ]
+
+    prog = (
+        f"from {main_module} import main; import sys; "
+        f"sys.exit(main("
+        f"{', '.join(_format_arg(name, value) for name, value in kwargs.items())}"
+        f"))"
+    )
+    opts = util._args_from_interpreter_flags()
+    return [get_executable(), *opts, "-c", prog, *extra_args]
+
+
+def freeze_support():
+    """Run code for the child workers when necessary.
+    This helper allows the frozen executable to call the code for the child
+    workers when not in the main process.
+    It should be called right after the beginning of the programme, to
+    avoid recursive process spawning.
+    """
+    if _is_loky_forking(sys.argv):
+        main_module = sys.argv[2]
+        kwargs = dict(_parse_arg(arg) for arg in sys.argv[3:])
+        main = importlib.import_module(main_module).main
+        sys.exit(main(**kwargs))
+
+    mp_freeze_support()
+
+
 def _check_not_importing_main():
     if getattr(process.current_process(), "_inheriting", False):
-        raise RuntimeError(
-            textwrap.dedent(
-                """\
+        raise RuntimeError(textwrap.dedent("""\
             An attempt has been made to start a new process before the
             current process has finished its bootstrapping phase.
 
@@ -51,9 +110,7 @@ def _check_not_importing_main():
                     ...
 
             The "freeze_support()" line can be omitted if the program
-            is not going to be frozen to produce an executable."""
-            )
-        )
+            is not going to be frozen to produce an executable."""))
 
 
 def get_preparation_data(name, init_main_module=True):

--- a/tests/test_loky_module.py
+++ b/tests/test_loky_module.py
@@ -4,6 +4,7 @@ import sys
 import shutil
 import subprocess
 import tempfile
+import textwrap
 import warnings
 from subprocess import check_output
 from unittest.mock import patch, mock_open
@@ -291,3 +292,93 @@ def test_cpu_count_cgroup_invalid_content(read_data, description):
             assert (
                 result == os_cpu_count
             ), f"cpu.max with {description} should return os_cpu_count"
+
+
+def test_freeze_support_with_pyinstaller(tmp_path):
+    if sys.implementation.name != "cpython":
+        pytest.skip("PyInstaller support is only tested on CPython")
+
+    pyinstaller = shutil.which("pyinstaller")
+    if pyinstaller is None:
+        pytest.skip("PyInstaller is not installed")
+
+    loky_project_path = os.path.abspath(
+        os.path.join(os.path.dirname(loky.__file__), os.pardir)
+    )
+    source = tmp_path / "frozen_loky.py"
+    source.write_text(
+        textwrap.dedent("""
+            import argparse
+            import loky
+
+
+            def main():
+                parser = argparse.ArgumentParser()
+                parser.add_argument("--parent-process", action="store_true")
+                args = parser.parse_args()
+                if not args.parent_process:
+                    raise RuntimeError("main() was called in a child process")
+
+                executor = loky.get_reusable_executor(max_workers=2)
+                try:
+                    print(sum(executor.map(int, range(10))))
+                    print(sum(executor.map(lambda x: x ** 2, range(1000))))
+                finally:
+                    executor.shutdown(wait=True)
+
+
+            if __name__ == "__main__":
+                loky.freeze_support()
+                main()
+            """),
+        encoding="utf-8",
+    )
+
+    python_cmd = [sys.executable, str(source), "--parent-process"]
+    non_frozen = subprocess.run(
+        python_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+
+    subprocess.run(
+        [
+            pyinstaller,
+            "--noconfirm",
+            "--onefile",
+            "--distpath",
+            str(tmp_path / "dist"),
+            "--workpath",
+            str(tmp_path / "build"),
+            "--specpath",
+            str(tmp_path),
+            "--paths",
+            loky_project_path,
+            str(source),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+        timeout=240,
+    )
+
+    executable = tmp_path / "dist" / "frozen_loky"
+    if sys.platform == "win32":
+        executable = executable.with_suffix(".exe")
+
+    frozen = subprocess.run(
+        [str(executable), "--parent-process"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+        timeout=120,
+    )
+
+    expected_stdout = "45\n332833500\n"
+    assert frozen.stdout == non_frozen.stdout == expected_stdout
+    assert frozen.stderr == non_frozen.stderr == ""

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -8,6 +8,7 @@ import re
 import signal
 import subprocess
 import sys
+import textwrap
 import time
 import warnings
 import weakref
@@ -97,6 +98,50 @@ class TestResourceTracker:
 
         pattern = f"KeyError: '{filename}'"
         assert pattern not in p.stderr
+
+    @pytest.mark.skipif(
+        sys.platform != "win32", reason="Windows specific test"
+    )
+    def test_resource_tracker_does_not_inherit_unrelated_handles(self):
+        cmd = textwrap.dedent("""
+            import _winapi
+            import os
+            import sys
+
+            from loky.backend import resource_tracker
+
+            rhandle, whandle = _winapi.CreatePipe(None, 0)
+            try:
+                os.set_handle_inheritable(whandle, True)
+                resource_tracker.ensure_running()
+                _winapi.CloseHandle(whandle)
+                whandle = None
+
+                try:
+                    _winapi.PeekNamedPipe(rhandle, 0)
+                except BrokenPipeError:
+                    pass
+                else:
+                    raise RuntimeError(
+                        "resource tracker inherited an unrelated handle"
+                    )
+            finally:
+                try:
+                    resource_tracker._resource_tracker._stop()
+                finally:
+                    if whandle is not None:
+                        _winapi.CloseHandle(whandle)
+                    _winapi.CloseHandle(rhandle)
+            """)
+
+        p = subprocess.run(
+            [sys.executable, "-c", cmd],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+        )
+        assert p.returncode == 0, p.stderr
 
     # The following four tests are inspired from cpython _test_multiprocessing
     @pytest.mark.parametrize("rtype", ["file", "folder", "semlock"])


### PR DESCRIPTION
This supersedes #375 and addresses #236 and joblib/joblib#1002.

The main design of adding a dedicated `freeze_support` is directly ported from #375. There are minor differences in the implementation like the fact that bootstrapping are kept in popen modules instead of writing platform-dependent code inside shared modules.

I've noticed #375 also involves patches as an attempt to fix Windows, but I have failed to reproduce the problems on a Windows machine on the latest version of pyinstaller. Doing a binary search, the error reported in https://github.com/joblib/loky/pull/375#issuecomment-1439830399 seems to have been fixed since pyinstaller v6.10.0, in particular with pyinstaller/pyinstaller#8634.