### PR TITLE
Add support for Python 3.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,14 +49,16 @@ jobs:
           - name: windows-py313
             os: windows-latest
             PYTHON_VERSION: "3.13"
+            EXTRA_PACKAGES: "numpy tblib"
           - name: windows-py39
             os: windows-latest
             PYTHON_VERSION: "3.9"
             LOKY_TEST_NO_CIM: "true"
-
+            EXTRA_PACKAGES: "numpy tblib"
           - name: macos-py313
             os: macos-latest
             PYTHON_VERSION: "3.13"
+            EXTRA_PACKAGES: "numpy tblib"
           - name: macos-py39
             os: macos-latest
             PYTHON_VERSION: "3.9"
@@ -69,14 +71,16 @@ jobs:
             os: ubuntu-latest
             PYTHON_VERSION: "3.14"
             FREE_THREADING: "true"
+            EXTRA_PACKAGES: "numpy tblib"
           - name: linux-py314
             os: ubuntu-latest
             PYTHON_VERSION: "3.14"
+            EXTRA_PACKAGES: "numpy tblib"
           - name: linux-py313
             os: ubuntu-latest
             PYTHON_VERSION: "3.13"
             LOKY_TEST_NO_LSCPU: "true"
-            EXTRA_PACKAGES: "viztracer"
+            EXTRA_PACKAGES: "numpy tblib viztracer"
           - name: linux-py39-joblib-tests
             os: ubuntu-latest
             PYTHON_VERSION: "3.9"
@@ -85,6 +89,7 @@ jobs:
             os: ubuntu-latest
             PYTHON_VERSION: "3.9"
             RUN_MEMORY: "true"
+            EXTRA_PACKAGES: "numpy tblib"
           - name: linux-py39
             os: ubuntu-latest
             PYTHON_VERSION: "3.9"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           - name: linux-py315
             os: ubuntu-latest
             PYTHON_VERSION: "3.15.0a8"
-            CONDA_CHANNEL: "conda-forge/label/python_dev"
+            CONDA_CHANNEL_OPTS: "-c conda-forge -c conda-forge/label/python_dev -c conda-forge/label/python_rc"
           - name: linux-py314-free-threading
             os: ubuntu-latest
             PYTHON_VERSION: "3.14"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,11 +61,17 @@ jobs:
             os: macos-latest
             PYTHON_VERSION: "3.9"
 
+          - name: linux-py315
+            os: ubuntu-latest
+            PYTHON_VERSION: "3.15.0a8"
+            CONDA_CHANNEL: "conda-forge/label/python_dev"
           - name: linux-py314-free-threading
             os: ubuntu-latest
-            PYTHON_VERSION: "3.14.0rc2"
-            CONDA_CHANNEL: "conda-forge/label/python_rc"
+            PYTHON_VERSION: "3.14"
             FREE_THREADING: "true"
+          - name: linux-py314
+            os: ubuntu-latest
+            PYTHON_VERSION: "3.14"
           - name: linux-py313
             os: ubuntu-latest
             PYTHON_VERSION: "3.13"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 - Support detection of the number of physical cores in
   `cpu_count(only_physical_cores=True)` on FreeBSD.
 
+- Support Python 3.15. (#626)
+
 ### 3.5.6 - 2025-08-27
 
 - Fix ``resource_tracker`` compatibility with python 3.13.7+. (#461)

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -14,12 +14,12 @@ else
 fi
 
 # If the conda channel is not explicitly set, use conda-forge:
-if [[ -z "$CONDA_CHANNEL" ]]; then
-    CONDA_CHANNEL="conda-forge"
+if [[ -z "$CONDA_CHANNEL_OPTS" ]]; then
+    CONDA_CHANNEL_OPTS="-c conda-forge"
 fi
 
 to_install="$PYTHON_PACKAGE=$PYTHON_VERSION pip numpy tblib $EXTRA_PACKAGES"
-conda create -n testenv --yes -c $CONDA_CHANNEL $to_install
+conda create -n testenv --yes $CONDA_CHANNEL_OPTS $to_install
 conda activate testenv
 
 if [[ -z "$JOBLIB_TESTS" ]]; then

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -18,7 +18,7 @@ if [[ -z "$CONDA_CHANNEL_OPTS" ]]; then
     CONDA_CHANNEL_OPTS="-c conda-forge"
 fi
 
-to_install="$PYTHON_PACKAGE=$PYTHON_VERSION pip numpy tblib $EXTRA_PACKAGES"
+to_install="$PYTHON_PACKAGE=$PYTHON_VERSION pip $EXTRA_PACKAGES"
 conda create -n testenv --yes $CONDA_CHANNEL_OPTS $to_install
 conda activate testenv
 

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -43,6 +43,15 @@ import shutil
 import sys
 import signal
 import warnings
+
+# Python 3.15+ uses JSON format for resource tracker messages
+try:
+    from multiprocessing.resource_tracker import _decode_message
+
+    _HAS_DECODE_MESSAGE = True
+except ImportError:
+    _HAS_DECODE_MESSAGE = False
+
 from multiprocessing import util
 from multiprocessing.resource_tracker import (
     ResourceTracker as _ResourceTracker,
@@ -284,14 +293,17 @@ def main(fd, verbose=0):
         with open(fd, "rb") as f:
             for line in f:
                 try:
-                    splitted = line.strip().decode("ascii").split(":")
-                    # name can potentially contain separator symbols (for
-                    # instance folders on Windows)
-                    cmd, name, rtype = (
-                        splitted[0],
-                        ":".join(splitted[1:-1]),
-                        splitted[-1],
-                    )
+                    if _HAS_DECODE_MESSAGE:
+                        # Python 3.15+ uses JSON format; _decode_message handles both
+                        cmd, rtype, name = _decode_message(line)
+                    else:
+                        # Old format: CMD:name:rtype (name can contain ":")
+                        splitted = line.strip().decode("ascii").split(":")
+                        cmd, name, rtype = (
+                            splitted[0],
+                            ":".join(splitted[1:-1]),
+                            splitted[-1],
+                        )
 
                     if rtype not in _CLEANUP_FUNCS:
                         raise ValueError(


### PR DESCRIPTION
Fixes #624 

As I said in the issue, I'm not sure this is enough, but it makes all the tests of joblib pass with Python 3.15.

By the way, 3.15 beta 1 should be out today, so we can wait a bit and update it.