### PR TITLE
CI adapt joblib test as cloudpickle is not vendored in joblib anymore

### DIFF
--- a/continuous_integration/copy_loky.sh
+++ b/continuous_integration/copy_loky.sh
@@ -20,12 +20,6 @@ rm -rf $INSTALL_FOLDER
 find loky -name "*.py" | xargs sed -i.bak "s/from loky/from joblib.externals.loky/"
 sed -i.bak "s/loky.backend.popen_loky/joblib.externals.loky.backend.popen_loky/" loky/backend/popen_loky_posix.py
 
-for f in $(git grep -l "cloudpickle" loky); do
-    echo $f;
-    sed -i.bak 's/import cloudpickle/from joblib.externals import cloudpickle/' $f
-    sed -i.bak 's/from cloudpickle import/from joblib.externals.cloudpickle import/' $f
-done
-
 
 
 # Note: BSD sed -i needs an argument unders OSX


### PR DESCRIPTION
The CI is failing due to our script that is still trying to use vendored version or `cloudpickle` in `joblib` while it is now a dependency.