### PR TITLE
loky: remove misleading set_start_method docs and refresh Task & results serialization section

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -15,7 +15,7 @@ Task & results serialization
 
 To share function definition across multiple python processes, it is necessary to rely on a serialization protocol. The standard protocol in python is :mod:`pickle` but its default implementation in the standard library has several limitations. For instance, it cannot serialize functions which are defined interactively or in the :code:`__main__` module.
 
-To avoid this limitation, :mod:`loky` relies on |cloudpickle| when it is present. |cloudpickle| is a fork of the pickle protocol which allows the serialization of a greater number of objects and it can be installed using :code:`pip install cloudpickle`. As this library is slower than the :mod:`pickle` module in the standard library, by default, :mod:`loky` uses it only to serialize objects which are detected to be in the :code:`__main__` module.
+To avoid this limitation, :mod:`loky` relies on |cloudpickle| when it is present. |cloudpickle| is a fork of the pickle protocol which allows the serialization of a greater number of objects and it can be installed using :code:`pip install cloudpickle`. |cloudpickle| is used by default to serialize tasks and results, because it can handle interactively defined functions, lambdas, and locally defined classes that the standard pickle module cannot pickle. Recent versions of |cloudpickle| are based on the C implementation of pickle, so this is not a significant performance trade-off compared to plain pickle for most workloads.
 
 There are three ways to temper with the serialization in :mod:`loky`:
 
@@ -27,13 +27,6 @@ The benefits and drawbacks of each method are highlighted in this example_.
 
 
 .. autofunction:: loky.wrap_non_picklable_objects
-
-
-Processes start methods in :mod:`loky`
---------------------------------------
-
-The API in :mod:`loky` provides a :func:`set_start_method` function to set the default  :code:`start_method`, which controls the way :class:`Process` are started. The available methods are {:code:`'loky'`, :code:`'loky_int_main'`, :code:`'spawn'`}. On unix, the start methods {:code:`'fork'`, :code:`'forkserver'`} are also available.
-Note that :mod:`loky` is not compatible with :func:`multiprocessing.set_start_method` function. The default start method needs to be set with the provided function to ensure a proper behavior.
 
 
 Protection against memory leaks


### PR DESCRIPTION
## Summary

Single-file edit to `docs/API.rst`.

1. Remove the "Processes start methods in `loky`" section header and its body. This is the entire block beginning `Processes start methods in :mod:\`loky\`` and ending before "Protection against memory leaks". The section currently lives between the `autofunction:: loky.wrap_non_picklable_objects` directive and the "Protection against memory leaks" heading.

2. In the "Task & results serialization" section, rewrite the paragraph that currently reads:

   > As this library is slower than the pickle module in the standard library, by default, loky uses it only to serialize objects which are detected to be in the __main__ module.

   New wording (keep the same overall flow, just correct the two outdated claims):

   > cloudpickle is used by default to serialize tasks and results, because it can handle interactively defined functions, lambdas, and locally defined classes that the standard pickle module cannot pickle. Recent versions of cloudpickle are based on the C implementation of pickle, so this is not a significant performance trade-off compared to plain pickle for most workloads.

3. Keep the existing list of three ways to control serialization (`job_reducers`/`result_reducers`, `LOKY_PICKLER`, `wrap_non_picklable_objects`) verbatim. Do not change them in this PR; deprecation of `wrap_non_picklable_objects` is out of scope per the deferral above.

4. Build the docs locally to verify no Sphinx warnings or broken cross-references are introduced (the removed section did not contain any `.. _xxx:` labels that other pages link to; a quick `grep -r "set_start_method" docs/` after the edit confirms no leftover references).

PR title: `DOC Remove misleading set_start_method section and refresh cloudpickle wording`

PR body (concise, factual):

> Closes #404.
>
> - Removes the `Processes start methods in loky` section from `docs/API.rst`. `loky.set_start_method` is not exposed at the top-level `loky` module, so documenting it as public API was misleading.
> - Rewords the cloudpickle paragraph in `Task & results serialization` to remove the "slower than pickle" claim (no longer true with cloudpickle's C-pickle base) and the "only objects detected to be in __main__" claim (loky in fact uses cloudpickle for everything cloudpickle can handle).
>
> Per the maintainer comment on the issue, deprecating `loky.wrap_non_picklable_objects` and the `loky_init_main` start method is left for a separate PR since it requires a runtime deprecation cycle.

## Why this matters

Issue #404 reports that the loky docs imply `loky.set_start_method` is public API, when the actual import path is `loky.backend.context.set_start_method` and the function is not exposed at the top-level module. Maintainer @ogrisel responded on 2025-03-06 stating he does not see value in changing the start method at the loky level, and proposed three concrete docs cleanups in the same comment:

1. Delete the "Processes start methods in `loky`" section in `docs/API.rst` so the docs stop implying `loky.set_start_method` is public API.
2. Update the "Task & results serialization" section. Two statements there are no longer accurate:
   - "As this library [cloudpickle] is slower than the pickle module in the standard library" - no longer true now that cloudpickle is built on the C pickle implementation.
   - "by default, loky uses it only to serialize objects which are detected to be in the __main__ module" - the current behavior is that cloudpickle is used for all objects (including locally defined functions outside `__main__`), as demonstrated by the small reproducer in the maintainer comment.
3. (Deferred from this plan) Deprecate `loky.wrap_non_picklable_objects` and the `loky_init_main` start method. These touch runtime code and the deprecation cycle is a larger conversation; this PR will keep the autofunction directive for `wrap_non_picklable_objects` so the deprecation can be staged in a follow-up.

## Testing

- `cd docs && make html` completes without new Sphinx warnings or errors compared to a clean `master` build (capture both before and after stderr to diff).
- `grep -rn "set_start_method" docs/` returns no matches after the edit. (Before the edit, it matches the section being removed.)
- `grep -rn "slower than the :mod:\`pickle\`" docs/` returns no matches after the edit.
- Open the generated `docs/_build/html/API.html` locally and visually confirm that the API page renders, the autofunction directive for `wrap_non_picklable_objects` still appears, and the Protection against memory leaks section now follows the Task & results serialization section directly.
- ReadTheDocs preview build (auto-triggered by the PR) succeeds.

Fixes #404

AI was used for assistance.
