### PR TITLE
FIX Prevent flashing console windows on Windows powershell commands

### DIFF
--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -304,6 +304,7 @@ def _count_physical_cores_win32():
             f"powershell.exe {cmd}".split(),
             capture_output=True,
             text=True,
+            creationflags=subprocess.CREATE_NO_WINDOW,
         )
         cpu_info = cpu_info.stdout.splitlines()
         return int(cpu_info[0])
@@ -314,6 +315,7 @@ def _count_physical_cores_win32():
         "wmic CPU Get NumberOfCores /Format:csv".split(),
         capture_output=True,
         text=True,
+        creationflags=subprocess.CREATE_NO_WINDOW,
     )
     cpu_info = cpu_info.stdout.splitlines()
     cpu_info = [

--- a/loky/backend/utils.py
+++ b/loky/backend/utils.py
@@ -79,7 +79,9 @@ def _windows_taskkill_process_tree(pid):
     # process pid and its children.
     try:
         subprocess.check_output(
-            ["taskkill", "/F", "/T", "/PID", str(pid)], stderr=None
+            ["taskkill", "/F", "/T", "/PID", str(pid)],
+            stderr=None,
+            creationflags=subprocess.CREATE_NO_WINDOW,
         )
     except subprocess.CalledProcessError as e:
         # In Windows, taskkill returns 128, 255 for no process found.


### PR DESCRIPTION
## Description
This PR fixes a user experience issue on Windows where brief, empty console windows flash on the screen when using `joblib` within a windowed application (e.g., `pythonw.exe`, GUI frameworks, or packaged desktop apps). 

The flashing console issue occurs in two distinct subprocess invocation scenarios on Windows:
1. **Startup (Physical Core Detection):** When `joblib.externals.loky.backend.context._count_physical_cores_win32()` calls `powershell.exe` and its fallback `wmic`.
2. **Cleanup (Worker Termination):** When `joblib.externals.loky.backend.utils._windows_taskkill_process_tree()` calls the `taskkill` command to forcefully terminate a process tree.

This PR ensures these external commands are executed silently in the background.

## Changes Proposed
* **`loky/backend/context.py`**: Added `creationflags=subprocess.CREATE_NO_WINDOW` to the `subprocess.run` calls for both the `powershell` and `wmic` paths.
* **`loky/backend/utils.py`**: Added `creationflags=subprocess.CREATE_NO_WINDOW` to the subprocess call in `_windows_taskkill_process_tree()`.
* **Cross-Platform Safety**: Accessed the flag explicitly via the `subprocess` module (`subprocess.CREATE_NO_WINDOW`) rather than using a top-level `from subprocess import CREATE_NO_WINDOW`. This prevents `NameError` or `ImportError` on non-Windows platforms where this constant is not defined.

## Steps to Verify / Reproduce
1. On Windows, run the following via a windowed Python process (`pythonw.exe`) or a GUI application:
   * **Trigger Core Detection:** Call `joblib.externals.loky.backend.context.cpu_count(only_physical_cores=True)`
   * **Trigger Process Termination:** Forcefully kill a Loky worker process tree to trigger `_windows_taskkill_process_tree()`.
2. **Before this PR:** A console window flashes on the screen during both the detection and termination phases.
3. **After this PR:** All subprocesses are launched silently with no visible console window.

## Environment Details
* OS: Windows
* Application type: GUI / windowed Python app (`pythonw.exe` or packaged executables)