### PR TITLE
Fix bare except: use except Exception in physical core count fallbacks

### DIFF
--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -286,7 +286,7 @@ def _count_physical_cores_linux():
         cpu_info = cpu_info.stdout.splitlines()
         cpu_info = {line for line in cpu_info if not line.startswith("#")}
         return len(cpu_info)
-    except:
+    except Exception:
         pass  # fallback to /proc/cpuinfo
 
     cpu_info = subprocess.run(
@@ -307,7 +307,7 @@ def _count_physical_cores_win32():
         )
         cpu_info = cpu_info.stdout.splitlines()
         return int(cpu_info[0])
-    except:
+    except Exception:
         pass  # fallback to wmic (older Windows versions; deprecated now)
 
     cpu_info = subprocess.run(


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` in two subprocess fallback paths in `loky/backend/context.py`.

**Changes:**

- `_count_physical_cores_linux()` (line 289): the `lscpu --parse=core` subprocess call falls back to `/proc/cpuinfo` on failure. The bare `except:` is replaced with `except Exception:`.
- `_count_physical_cores_win32()` (line 310): the PowerShell `Get-CimInstance` call falls back to `wmic` on older Windows versions. The bare `except:` is replaced with `except Exception:`.

**Motivation:**

Bare `except:` catches `BaseException`, including `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`. In these fallback paths, the only failures expected are subprocess errors (e.g. command not found, non-zero exit, parse errors), all of which are `Exception` subclasses. Using `except Exception:` keeps the fallback behavior identical while allowing process signals to propagate normally.

This fix was suggested during review of a related PR on the joblib repo (joblib/joblib#1822).