### PR TITLE
FIX wait on the tracker's process handle instead of its pid on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,3 +122,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,10 +12,10 @@
 
 - Wait on the tracker's process handle instead of its pid when stopping the
   ``resource_tracker`` on Windows. The inherited teardown ends in
-  ``os.waitpid``, which resolves the pid through ``OpenProcess``: once the
-  tracker has exited that either raises ``PermissionError: [Errno 13]`` or, if
-  the pid has been recycled, blocks the interpreter forever waiting on an
-  unrelated process.
+  ``os.waitpid``, which on Windows takes a process handle rather than a pid, so
+  passing the pid waits on whatever unrelated object happens to share that
+  value: this either raises ``PermissionError: [Errno 13]`` or blocks the
+  interpreter forever. This also stops leaking the tracker's process handle.
 
 - Drop support for Python 3.9, as it is no longer receiving security
   updates. (#647)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
   passing the pid waits on whatever unrelated object happens to share that
   value: this either raises ``PermissionError: [Errno 13]`` or blocks the
   interpreter forever. This also stops leaking the tracker's process handle.
+  (#643)
 
 - Drop support for Python 3.9, as it is no longer receiving security
   updates. (#647)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,13 @@
   submissions after executor replacement could raise
   ``ShutdownExecutorError``. (#632)
 
+- Wait on the tracker's process handle instead of its pid when stopping the
+  ``resource_tracker`` on Windows. The inherited teardown ends in
+  ``os.waitpid``, which resolves the pid through ``OpenProcess``: once the
+  tracker has exited that either raises ``PermissionError: [Errno 13]`` or, if
+  the pid has been recycled, blocks the interpreter forever waiting on an
+  unrelated process.
+
 ### 3.5.6 - 2025-08-27
 
 - Fix ``resource_tracker`` compatibility with python 3.13.7+. (#461)

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -265,11 +265,14 @@ class ResourceTracker(_ResourceTracker):
     def _stop_win32(self, close=os.close):
         """Stop the tracker without reaping it by pid.
 
-        The inherited teardown ends in ``os.waitpid(self._pid, 0)``, which on
-        Windows resolves the pid through ``OpenProcess``. Once the tracker has
-        exited that either fails with ``PermissionError`` or, if the pid has
-        been recycled, blocks forever on an unrelated process. Wait on the
-        handle from ``CreateProcess`` instead, which no recycling can alias.
+        The inherited teardown ends in ``os.waitpid(self._pid, 0)``. On Windows
+        that reaches the CRT's ``_cwait``, whose first argument is a process
+        *handle*, not a pid, so the pid is reinterpreted as a handle value in
+        this process's own table. Pids and handles are both multiples of four,
+        so it lands on an unrelated object often enough to matter: one without
+        SYNCHRONIZE access fails with ``PermissionError``, and a live one that
+        never signals blocks forever. Wait on the handle from ``CreateProcess``
+        instead, which actually names the tracker.
         """
         fd, self._fd = self._fd, None
         handle, self._proc_handle = self._proc_handle, None
@@ -444,14 +447,11 @@ def spawnv_passfds(path, args, passfds):
     else:
         passfds = sorted(passfds)
         cmd = " ".join(f'"{x}"' for x in args)
-        try:
-            hp, ht, pid, _ = _winapi.CreateProcess(
-                path, cmd, None, None, True, 0, None, None, None
-            )
-            _winapi.CloseHandle(ht)
-        except BaseException:
-            pass
-        # The process handle is kept rather than closed: waiting on the pid
-        # instead goes through OpenProcess, which is unsafe as soon as the pid
-        # can have been recycled.
+        hp, ht, pid, _ = _winapi.CreateProcess(
+            path, cmd, None, None, True, 0, None, None, None
+        )
+        _winapi.CloseHandle(ht)
+        # The process handle is kept rather than closed: os.waitpid needs a
+        # handle on Windows, and a pid passed in its place names whatever
+        # unrelated object shares that value in our handle table.
         return pid, hp

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -146,9 +146,9 @@ class ResourceTracker(_ResourceTracker):
             except OSError:
                 # The resource_tracker has already been terminated.
                 pass
-        elif self._proc_handle is not None:
+        elif (proc_handle := self._proc_handle) is not None:
             # Do not leak the handle when a dead tracker gets relaunched
-            _winapi.CloseHandle(self._proc_handle)
+            _winapi.CloseHandle(proc_handle)
         self._fd = None
         self._pid = None
         self._proc_handle = None
@@ -246,17 +246,20 @@ class ResourceTracker(_ResourceTracker):
         assert nbytes == len(msg), f"{nbytes=} != {len(msg)=}"
 
     def __del__(self):
-        # ignore error due to trying to clean up child process which has already been
-        # shutdown on windows. See https://github.com/joblib/loky/pull/450
-        # This is only required if __del__ is defined
+        # There is nothing to override on Python versions that do not define a
+        # destructor on the base class.
         if not hasattr(_ResourceTracker, "__del__"):
             return
         if sys.platform == "win32":
+            # Tearing down the tracker on Windows requires specific handling.
             self._stop_win32()
             return
         try:
             super().__del__()
         except ChildProcessError:
+            # ECHILD when the tracker is not a child of this process, e.g. in
+            # an os.fork()ed child that inherited _pid. cpython guards this
+            # itself since 3.13 (gh-140485) but 3.12 never got the backport.
             pass
 
     def _stop_win32(self, close=os.close):

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -90,6 +90,9 @@ if os.name == "posix":
 
 VERBOSE = False
 
+# Bound on how long the destructor waits for the tracker to exit on Windows
+_WIN32_STOP_TIMEOUT_MS = 1000
+
 
 class ResourceTracker(_ResourceTracker):
     """Resource tracker with refcounting scheme.
@@ -105,6 +108,9 @@ class ResourceTracker(_ResourceTracker):
     The actual implementation of the refcounting scheme is in the main
     function, which is run in a dedicated process.
     """
+
+    # Windows process handle of the tracker, see spawnv_passfds
+    _proc_handle = None
 
     def maybe_unlink(self, name, rtype):
         """Decrement the refcount of a resource, and delete it if it hits 0"""
@@ -140,8 +146,12 @@ class ResourceTracker(_ResourceTracker):
             except OSError:
                 # The resource_tracker has already been terminated.
                 pass
+        elif self._proc_handle is not None:
+            # Do not leak the handle when a dead tracker gets relaunched
+            _winapi.CloseHandle(self._proc_handle)
         self._fd = None
         self._pid = None
+        self._proc_handle = None
 
         warnings.warn(
             "resource_tracker: process died unexpectedly, relaunching. "
@@ -182,7 +192,7 @@ class ResourceTracker(_ResourceTracker):
             try:
                 if _HAVE_SIGMASK:
                     signal.pthread_sigmask(signal.SIG_BLOCK, _IGNORED_SIGNALS)
-                pid = spawnv_passfds(exe, args, fds_to_pass)
+                pid, proc_handle = spawnv_passfds(exe, args, fds_to_pass)
             finally:
                 if _HAVE_SIGMASK:
                     signal.pthread_sigmask(
@@ -194,6 +204,7 @@ class ResourceTracker(_ResourceTracker):
         else:
             self._fd = w
             self._pid = pid
+            self._proc_handle = proc_handle
         finally:
             if sys.platform == "win32":
                 _winapi.CloseHandle(r)
@@ -240,10 +251,35 @@ class ResourceTracker(_ResourceTracker):
         # This is only required if __del__ is defined
         if not hasattr(_ResourceTracker, "__del__"):
             return
+        if sys.platform == "win32":
+            self._stop_win32()
+            return
         try:
             super().__del__()
         except ChildProcessError:
             pass
+
+    def _stop_win32(self, close=os.close):
+        """Stop the tracker without reaping it by pid.
+
+        The inherited teardown ends in ``os.waitpid(self._pid, 0)``, which on
+        Windows resolves the pid through ``OpenProcess``. Once the tracker has
+        exited that either fails with ``PermissionError`` or, if the pid has
+        been recycled, blocks forever on an unrelated process. Wait on the
+        handle from ``CreateProcess`` instead, which no recycling can alias.
+        """
+        fd, self._fd = self._fd, None
+        handle, self._proc_handle = self._proc_handle, None
+        self._pid = None
+        if fd is not None:
+            # Closing the "alive" file descriptor stops main()
+            close(fd)
+        # _winapi can already be torn down when this runs from a finalizer
+        if handle is not None and _winapi is not None:
+            try:
+                _winapi.WaitForSingleObject(handle, _WIN32_STOP_TIMEOUT_MS)
+            finally:
+                _winapi.CloseHandle(handle)
 
 
 _resource_tracker = ResourceTracker()
@@ -394,18 +430,25 @@ def main(fd, verbose=0):
 
 
 def spawnv_passfds(path, args, passfds):
+    """Spawn the tracker and return its ``(pid, handle)``.
+
+    ``handle`` is the Windows process handle, and None elsewhere.
+    """
     if sys.platform != "win32":
         args = [arg.encode("utf-8") for arg in args]
         path = path.encode("utf-8")
-        return util.spawnv_passfds(path, args, passfds)
+        return util.spawnv_passfds(path, args, passfds), None
     else:
         passfds = sorted(passfds)
         cmd = " ".join(f'"{x}"' for x in args)
         try:
-            _, ht, pid, _ = _winapi.CreateProcess(
+            hp, ht, pid, _ = _winapi.CreateProcess(
                 path, cmd, None, None, True, 0, None, None, None
             )
             _winapi.CloseHandle(ht)
         except BaseException:
             pass
-        return pid
+        # The process handle is kept rather than closed: waiting on the pid
+        # instead goes through OpenProcess, which is unsafe as soon as the pid
+        # can have been recycled.
+        return pid, hp

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -303,7 +303,8 @@ class TestResourceTracker:
     )
     def test_resource_tracker_del_already_reaped(self, monkeypatch):
         # An already reaped tracker raises ChildProcessError from os.waitpid,
-        # which must not escape the destructor.
+        # which must not escape the destructor. Still needed on 3.12, whose
+        # _stop_locked has an unguarded waitpid (see joblib/joblib#1708).
         base = resource_tracker._ResourceTracker
         if not hasattr(base, "__del__"):
             pytest.skip("this Python version has no ResourceTracker.__del__")

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -289,6 +289,57 @@ class TestResourceTracker:
         # Uncatchable signal.
         self.check_resource_tracker_death(signal.SIGKILL, True)
 
+    def test_resource_tracker_keeps_process_handle(self):
+        # The pid alone is not enough to reap the tracker safely on Windows
+        resource_tracker.ensure_running()
+        handle = resource_tracker._resource_tracker._proc_handle
+        if sys.platform == "win32":
+            assert handle is not None
+        else:
+            assert handle is None
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="posix-only teardown path"
+    )
+    def test_resource_tracker_del_already_reaped(self, monkeypatch):
+        # An already reaped tracker raises ChildProcessError from os.waitpid,
+        # which must not escape the destructor.
+        base = resource_tracker._ResourceTracker
+        if not hasattr(base, "__del__"):
+            pytest.skip("this Python version has no ResourceTracker.__del__")
+
+        def raising_del(self):
+            raise ChildProcessError(errno.ECHILD, "No child processes")
+
+        monkeypatch.setattr(base, "__del__", raising_del)
+        resource_tracker.ResourceTracker().__del__()
+
+    def test_resource_tracker_del_does_not_reap_by_pid_on_win32(
+        self, monkeypatch
+    ):
+        # Non-regression test: the inherited teardown ends in os.waitpid, which
+        # on Windows resolves the pid through OpenProcess and then either fails
+        # or blocks forever on a recycled pid, so it must not be reached there.
+        base = resource_tracker._ResourceTracker
+        if not hasattr(base, "__del__"):
+            pytest.skip("this Python version has no ResourceTracker.__del__")
+
+        reaped = []
+        monkeypatch.setattr(base, "__del__", lambda self: reaped.append(True))
+        monkeypatch.setattr(sys, "platform", "win32")
+
+        tracker = resource_tracker.ResourceTracker()
+        r, w = os.pipe()
+        os.close(r)
+        tracker._fd, tracker._pid = w, 123456
+        tracker.__del__()
+
+        assert not reaped, "the destructor reaped the tracker by pid"
+        assert tracker._fd is None and tracker._pid is None
+        with pytest.raises(OSError):
+            # the "alive" fd must have been closed to stop the tracker
+            os.close(w)
+
     def test_loky_process_inherit_multiprocessing_resource_tracker(self):
         cmd = """if 1:
         from loky import get_reusable_executor

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -1,5 +1,6 @@
 """Tests for the ResourceTracker class"""
 
+import ctypes
 import errno
 import gc
 import os
@@ -11,6 +12,7 @@ import sys
 import time
 import warnings
 import weakref
+from ctypes import wintypes
 
 from loky import ProcessPoolExecutor
 import loky.backend.resource_tracker as resource_tracker
@@ -353,9 +355,9 @@ class TestResourceTracker:
         os.close(w)
 
     def test_resource_tracker_stop_win32_waits_on_handle(self, monkeypatch):
-        # The point of the fix: reap through the CreateProcess handle, bounded,
-        # rather than through the pid, which OpenProcess can resolve to a
-        # recycled and unrelated process.
+        # The point of the fix: wait on the CreateProcess handle, bounded,
+        # rather than on the pid, which os.waitpid reinterprets as a handle
+        # value naming some unrelated object.
         winapi = _RecordingWinapi()
         monkeypatch.setattr(resource_tracker, "_winapi", winapi, raising=False)
         tracker, w = _make_stopped_tracker()
@@ -403,8 +405,9 @@ class TestResourceTracker:
         self, monkeypatch
     ):
         # Non-regression test: the inherited teardown ends in os.waitpid, which
-        # on Windows resolves the pid through OpenProcess and then either fails
-        # or blocks forever on a recycled pid, so it must not be reached there.
+        # on Windows takes a process handle, so passing the pid waits on an
+        # unrelated object and either fails or blocks forever. It must not be
+        # reached there.
         base = resource_tracker._ResourceTracker
         if not hasattr(base, "__del__"):
             pytest.skip("this Python version has no ResourceTracker.__del__")
@@ -424,6 +427,43 @@ class TestResourceTracker:
         with pytest.raises(OSError):
             # the "alive" fd must have been closed to stop the tracker
             os.close(w)
+
+    @pytest.mark.skipif(
+        sys.platform != "win32", reason="win32-only teardown path"
+    )
+    def test_resource_tracker_del_survives_a_foreign_pid_value(self):
+        # End-to-end regression test for #642 against a real running tracker.
+        # os.waitpid takes a process handle on Windows, so _pid is
+        # reinterpreted as a handle value in our own table; CI hit that
+        # collision by chance. Force it with a handle that is live but lacks
+        # SYNCHRONIZE, which is what turns the inherited teardown into
+        # PermissionError. A value naming a live never-signalled object would
+        # hang instead, so this is the variant that is safe to assert on.
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.OpenProcess.argtypes = [
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        ]
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        handle = kernel32.OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION, False, os.getpid()
+        )
+        assert handle, ctypes.WinError(ctypes.get_last_error())
+
+        try:
+            tracker = resource_tracker.ResourceTracker()
+            tracker.ensure_running()
+            tracker._pid = int(handle)
+            # Must not raise PermissionError, and must not reap by pid
+            tracker.__del__()
+
+            assert tracker._fd is None
+            assert tracker._proc_handle is None
+        finally:
+            kernel32.CloseHandle(handle)
 
     def test_loky_process_inherit_multiprocessing_resource_tracker(self):
         cmd = """if 1:

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -28,6 +28,32 @@ def get_rtracker_fd():
     return resource_tracker._resource_tracker._fd
 
 
+class _RecordingWinapi:
+    """Stand-in for _winapi so the win32 paths can be tested on any platform"""
+
+    def __init__(self, create_process=None):
+        self.waited = []
+        self.closed = []
+        self._create_process = create_process
+
+    def WaitForSingleObject(self, handle, timeout):
+        self.waited.append((handle, timeout))
+
+    def CloseHandle(self, handle):
+        self.closed.append(handle)
+
+    def CreateProcess(self, *args):
+        return self._create_process
+
+
+def _make_stopped_tracker(handle=42):
+    tracker = resource_tracker.ResourceTracker()
+    r, w = os.pipe()
+    os.close(r)
+    tracker._fd, tracker._pid, tracker._proc_handle = w, 123456, handle
+    return tracker, w
+
+
 class TestResourceTracker:
     @pytest.mark.parametrize("rtype", ["file", "folder", "semlock"])
     def test_resource_utils(self, rtype):
@@ -314,6 +340,64 @@ class TestResourceTracker:
 
         monkeypatch.setattr(base, "__del__", raising_del)
         resource_tracker.ResourceTracker().__del__()
+
+    def test_resource_tracker_del_without_base_del(self, monkeypatch):
+        # Nothing to override before cpython grew a destructor (gh-88887)
+        monkeypatch.delattr(
+            resource_tracker._ResourceTracker, "__del__", raising=False
+        )
+        tracker, w = _make_stopped_tracker()
+        tracker.__del__()
+
+        assert tracker._fd == w
+        os.close(w)
+
+    def test_resource_tracker_stop_win32_waits_on_handle(self, monkeypatch):
+        # The point of the fix: reap through the CreateProcess handle, bounded,
+        # rather than through the pid, which OpenProcess can resolve to a
+        # recycled and unrelated process.
+        winapi = _RecordingWinapi()
+        monkeypatch.setattr(resource_tracker, "_winapi", winapi, raising=False)
+        tracker, w = _make_stopped_tracker()
+        tracker._stop_win32()
+
+        timeout = resource_tracker._WIN32_STOP_TIMEOUT_MS
+        assert winapi.waited == [(42, timeout)]
+        assert winapi.closed == [42]
+        assert tracker._fd is None
+        assert tracker._pid is None
+        assert tracker._proc_handle is None
+        with pytest.raises(OSError):
+            # the "alive" fd must have been closed to stop the tracker
+            os.close(w)
+
+    # a child that inherited the tracker has no handle of its own to close
+    @pytest.mark.parametrize("handle", [42, None])
+    def test_resource_tracker_relaunch_closes_handle(
+        self, monkeypatch, handle
+    ):
+        # A tracker that died and gets relaunched must not leak its handle
+        winapi = _RecordingWinapi()
+        monkeypatch.setattr(resource_tracker, "_winapi", winapi, raising=False)
+        monkeypatch.setattr(os, "name", "nt")
+        tracker, w = _make_stopped_tracker(handle=handle)
+        with pytest.warns(UserWarning, match="died unexpectedly"):
+            tracker._teardown_dead_process()
+
+        assert winapi.closed == ([] if handle is None else [handle])
+        assert tracker._proc_handle is None
+
+    def test_spawnv_passfds_keeps_the_process_handle(self, monkeypatch):
+        # Only the thread handle is closed; the process handle is returned
+        winapi = _RecordingWinapi(create_process=(42, 43, 123456, 0))
+        monkeypatch.setattr(resource_tracker, "_winapi", winapi, raising=False)
+        monkeypatch.setattr(sys, "platform", "win32")
+
+        assert resource_tracker.spawnv_passfds("exe", ["exe"], []) == (
+            123456,
+            42,
+        )
+        assert winapi.closed == [43]
 
     def test_resource_tracker_del_does_not_reap_by_pid_on_win32(
         self, monkeypatch

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -439,6 +439,12 @@ class TestResourceTracker:
         # SYNCHRONIZE, which is what turns the inherited teardown into
         # PermissionError. A value naming a live never-signalled object would
         # hang instead, so this is the variant that is safe to assert on.
+        base = resource_tracker._ResourceTracker
+        if not hasattr(base, "__del__"):
+            # Without one to override there is no teardown to reach, so the
+            # bug is not reachable either
+            pytest.skip("this Python version has no ResourceTracker.__del__")
+
         kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
         kernel32.OpenProcess.restype = wintypes.HANDLE
         kernel32.OpenProcess.argtypes = [


### PR DESCRIPTION
Closes #642, which has the tracebacks, the `py-spy` capture of the hang, and the mechanism.

> **AI disclosure:** this was written with Claude Opus 5 (via Claude Code) — the diagnosis, the patch, and the tests. I have reviewed all of it and can speak to it.

`spawnv_passfds` was discarding the process handle from `CreateProcess` and returning only the pid, which forces the inherited teardown to re-derive one via `OpenProcess`. This keeps the handle and waits on it with a 1s bound instead; no pid recycling can alias a handle. Reaping exists to avoid zombies, which is POSIX-only, so on Windows the wait was pure synchronisation and bounding it costs nothing.

Evidence beyond the loop in #642: vendoring this patch into joblib turns both of the `windows-latest` jobs that had been failing there, 3.11 and 3.12, [green](https://github.com/joblib/joblib/actions/runs/30320948369) — the same jobs that fail on joblib `main`.

Notes for review:

- POSIX behaviour is unchanged. `spawnv_passfds` now returns `(pid, handle)` instead of `pid`, with `handle` None off Windows; it has one caller.
- `_stop_win32` binds `os.close` as a default argument and null-checks `_winapi`, because it runs from a finalizer where module globals can already be torn down — the same reason CPython's `_stop_locked` takes `close=os.close`.
- The added test patches `sys.platform` and asserts the destructor never reaches the inherited teardown, so it runs off-Windows too. It fails without the change.
- Overlaps with #472: if the tracker gets vendored rather than derived from CPython, this belongs in that copy's `_stop_locked` instead. Happy to rebase whichever way you prefer.