### PR TITLE
ENH Make CPU count computation faster on Windows by using `-NoProfile` flag 

### DIFF
--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -299,7 +299,7 @@ def _count_physical_cores_linux():
 
 def _count_physical_cores_win32():
     try:
-        cmd = "-Command (Get-CimInstance -ClassName Win32_Processor).NumberOfCores"
+        cmd = "-NoProfile -Command (Get-CimInstance -ClassName Win32_Processor).NumberOfCores"
         cpu_info = subprocess.run(
             f"powershell.exe {cmd}".split(),
             capture_output=True,


### PR DESCRIPTION
## Issue: Avoid Loading PowerShell Profiles When Counting Physical CPU Cores on Windows

This PR adds the `-NoProfile` startup flag to the subprocess call to powershell.exe.  Since the command only performs a simple CIM query and does not depend on any user profile configuration, the profile can be skipped entirely by adding the `-NoProfile` flag.

See the discussion in [this joblib issue](https://github.com/joblib/loky/issues/644#issuecomment-5107399339)

### Benefits

- Decreases script run time.
- Avoids prompting for user input.

### Description

The current implementation of `_count_physical_cores_win32()` invokes PowerShell to query `Win32_Processor.NumberOfCores` loads the user's profile.
By default, PowerShell loads the user's profile before executing the command. In some environments, profile initialization can be slow (e.g., loading conda, Oh My Posh, custom modules, network resources, or other startup scripts).  

Additionally, on a system I work on, the user profile is located at a network-mapped path which causes PowerShell to prompt a security warning:

```
Security warning
Run only scripts that you trust. While scripts from the internet can be useful, this script can potentially harm your computer. 
If you trust this script, use the Unblock-File cmdlet to allow the script to run without this warning message. Do you want to run
\\some.network.location\Shares\Users\myuserid\Documents\WindowsPowerShell\profile.ps1?
```

### Proposed Change
Update the PowerShell invocation to include the `-NoProfile` flag.

```
cmd = "-NoProfile -Command (Get-CimInstance -ClassName Win32_Processor).NumberOfCores"
```