### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,17 +49,17 @@ jobs:
           - name: windows-py313
             os: windows-latest
             PYTHON_VERSION: "3.13"
-          - name: windows-py39
+          - name: windows-py310
             os: windows-latest
-            PYTHON_VERSION: "3.9"
+            PYTHON_VERSION: "3.10"
             LOKY_TEST_NO_CIM: "true"
 
           - name: macos-py313
             os: macos-latest
             PYTHON_VERSION: "3.13"
-          - name: macos-py39
+          - name: macos-py310
             os: macos-latest
-            PYTHON_VERSION: "3.9"
+            PYTHON_VERSION: "3.10"
 
           - name: linux-py314-free-threading
             os: ubuntu-latest
@@ -71,18 +71,18 @@ jobs:
             PYTHON_VERSION: "3.13"
             LOKY_TEST_NO_LSCPU: "true"
             EXTRA_PACKAGES: "viztracer"
-          - name: linux-py39-joblib-tests
+          - name: linux-py310-joblib-tests
             os: ubuntu-latest
-            PYTHON_VERSION: "3.9"
+            PYTHON_VERSION: "3.10"
             JOBLIB_TESTS: "true"
-          - name: linux-python-py39-high-memory
+          - name: linux-python-py310-high-memory
             os: ubuntu-latest
-            PYTHON_VERSION: "3.9"
+            PYTHON_VERSION: "3.10"
             RUN_MEMORY: "true"
-          - name: linux-py39
+          - name: linux-py310
             os: ubuntu-latest
-            PYTHON_VERSION: "3.9"
-            # Do not install psutil on Python 3.9 to have some CI runs that
+            PYTHON_VERSION: "3.10"
+            # Do not install psutil on Python 3.10 to have some CI runs that
             # tests that loky has no hard dependency on psutil.
             NO_PSUTIL: "true"
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,8 +10,8 @@
   submissions after executor replacement could raise
   ``ShutdownExecutorError``. (#632)
 
-- Dropped support for Python 3.9, as it is no longer receiving
-  security updates. (#647)
+- Drop support for Python 3.9, as it is no longer receiving security
+  updates. (#647)
 
 ### 3.5.6 - 2025-08-27
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
   submissions after executor replacement could raise
   ``ShutdownExecutorError``. (#632)
 
+- Dropped support for Python 3.9, as it is no longer receiving
+  security updates. (#TODO)
+
 ### 3.5.6 - 2025-08-27
 
 - Fix ``resource_tracker`` compatibility with python 3.13.7+. (#461)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
   ``ShutdownExecutorError``. (#632)
 
 - Dropped support for Python 3.9, as it is no longer receiving
-  security updates. (#TODO)
+  security updates. (#647)
 
 ### 3.5.6 - 2025-08-27
 

--- a/continuous_integration/runtests.sh
+++ b/continuous_integration/runtests.sh
@@ -21,7 +21,7 @@ if [[ "$JOBLIB_TESTS" == "true" ]]; then
     git clone https://github.com/joblib/joblib.git src_joblib
     cd src_joblib
     pip install pytest
-    pip install threadpoolctl  # required by some joblib tests
+    pip install threadpoolctl pytest-asyncio  # required by some joblib tests
 
     pip install -e .
     export JOBLIB=`python -c "import joblib; print(joblib.__path__[0])"`

--- a/continuous_integration/runtests.sh
+++ b/continuous_integration/runtests.sh
@@ -25,8 +25,11 @@ if [[ "$JOBLIB_TESTS" == "true" ]]; then
 
     pip install -e .
     export JOBLIB=`python -c "import joblib; print(joblib.__path__[0])"`
-    cp "$LOKY_PATH"/continuous_integration/copy_loky.sh $JOBLIB/externals
+    # Need to copy root conftest.py to inside joblib package since we are using
+    # pytest --pyargs joblib a few lines below
     cp conftest.py $JOBLIB/conftest.py
+    # Update vendored loky code inside joblib
+    cp "$LOKY_PATH"/continuous_integration/copy_loky.sh $JOBLIB/externals
     (cd $JOBLIB/externals && bash copy_loky.sh "$LOKY_PATH")
     pytest -vl --ignore $JOBLIB/externals --pyargs joblib
 else

--- a/continuous_integration/runtests.sh
+++ b/continuous_integration/runtests.sh
@@ -20,7 +20,7 @@ if [[ "$JOBLIB_TESTS" == "true" ]]; then
 
     git clone https://github.com/joblib/joblib.git src_joblib
     cd src_joblib
-    pip install "pytest<7.0"  # Need to update remove occurrences of pytest.warns(None)
+    pip install pytest
     pip install threadpoolctl  # required by some joblib tests
 
     pip install -e .

--- a/continuous_integration/runtests.sh
+++ b/continuous_integration/runtests.sh
@@ -26,6 +26,7 @@ if [[ "$JOBLIB_TESTS" == "true" ]]; then
     pip install -e .
     export JOBLIB=`python -c "import joblib; print(joblib.__path__[0])"`
     cp "$LOKY_PATH"/continuous_integration/copy_loky.sh $JOBLIB/externals
+    cp conftest.py $JOBLIB/conftest.py
     (cd $JOBLIB/externals && bash copy_loky.sh "$LOKY_PATH")
     pytest -vl --ignore $JOBLIB/externals --pyargs joblib
 else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description= "A robust implementation of concurrent.futures.ProcessPoolExecutor"
 authors = [{name = "Thomas Moreau", email = "thomas.moreau.2010@gmail.com"}]
 license= {file = "LICENSE.txt"}
 dependencies = ["cloudpickle"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -17,7 +17,6 @@ classifiers=[
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
3.9 is no longer receiving security updates as of last year.