### PR TITLE
Fix executor manager crash state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,12 @@
   with a ``KeyError`` when tasks were still queued, which skipped the cleanup
   of the executor's queues and processes. (#663)
 
+- Fix an error while reporting a task that failed to be sent to the workers
+  killing the call queue feeder thread silently, which left every later task
+  unsent so that waiting on a result hung forever. The executor is now flagged
+  as broken and the error is reported as the cause of the ``BrokenProcessPool``
+  raised by the futures. (#663)
+
 ### 3.6.0 - 2026-08-31
 
 - Support detection of the number of physical cores in

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 ### 3.7.0 - In development
 
+- Fix an unexpected error in the executor manager thread killing it silently,
+  which left every pending future unresolved so that waiting on a result hung
+  forever. The executor is now flagged as broken and the error is reported as
+  the cause of the ``BrokenProcessPool`` raised by the futures. (#663)
+
+- Fix ``shutdown(kill_workers=True)`` crashing the executor manager thread
+  with a ``KeyError`` when tasks were still queued, which skipped the cleanup
+  of the executor's queues and processes. (#663)
+
 ### 3.6.0 - 2026-08-31
 
 - Support detection of the number of physical cores in

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -616,7 +616,29 @@ class _ExecutorManagerThread(threading.Thread):
 
     def run(self):
         # Main loop for the executor manager thread.
+        try:
+            self._run_loop()
+        except BaseException as exc:
+            # Nothing in the loop is expected to raise, so this is a bug or a
+            # failure of the runtime itself, such as a queue that cannot
+            # start its feeder thread while the interpreter is shutting down
+            # (gh-109047). Letting the exception kill this thread would leave
+            # every pending future unresolved and the executor looking
+            # healthy, so a caller waiting on a result would hang forever.
+            # Flag the executor as broken instead, with the error as cause.
+            bpe = BrokenProcessPool(
+                "The executor manager thread crashed: the executor is broken "
+                "and the pending tasks have been cancelled."
+            )
+            tb = traceback.format_exception(type(exc), exc, exc.__traceback__)
+            bpe.__cause__ = _RemoteTraceback("".join(tb))
+            # Also log it: with no pending future, nothing else reports it
+            LOGGER.critical(
+                "Exception in executor manager thread:", exc_info=True
+            )
+            self.terminate_broken(bpe)
 
+    def _run_loop(self):
         while True:
             self.add_call_item_to_queue()
 
@@ -854,6 +876,13 @@ class _ExecutorManagerThread(threading.Thread):
 
         # Cancel pending work items if requested.
         if self.executor_flags.kill_workers:
+            # Drain the queued ids first: add_call_item_to_queue runs again
+            # right after this and looks each of them up in pending_work_items
+            while True:
+                try:
+                    self.work_ids_queue.get(block=False)
+                except queue.Empty:
+                    break
             while self.pending_work_items:
                 _, work_item = self.pending_work_items.popitem()
                 work_item.future.set_exception(

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -307,16 +307,25 @@ class _SafeQueue(Queue):
         running_work_items=None,
         thread_wakeup=None,
         shutdown_lock=None,
+        executor_flags=None,
         reducers=None,
     ):
         self.thread_wakeup = thread_wakeup
         self.shutdown_lock = shutdown_lock
+        self.executor_flags = executor_flags
         self.pending_work_items = pending_work_items
         self.running_work_items = running_work_items
         super().__init__(max_size, reducers=reducers, ctx=ctx)
 
     def _on_queue_feeder_error(self, e, obj):
-        if isinstance(obj, _CallItem):
+        if not isinstance(obj, _CallItem):
+            super()._on_queue_feeder_error(e, obj)
+            return
+        # work_item can be None if another process terminated. In this
+        # case, the executor_manager_thread fails all work_items with
+        # BrokenProcessPool
+        work_item = self.pending_work_items.pop(obj.work_id, None)
+        try:
             # format traceback only works on python3
             if isinstance(e, struct.error):
                 raised_error = RuntimeError(
@@ -331,18 +340,27 @@ class _SafeQueue(Queue):
                 type(e), e, getattr(e, "__traceback__", None)
             )
             raised_error.__cause__ = _RemoteTraceback("".join(tb))
-            work_item = self.pending_work_items.pop(obj.work_id, None)
             self.running_work_items.remove(obj.work_id)
-            # work_item can be None if another process terminated. In this
-            # case, the executor_manager_thread fails all work_items with
-            # BrokenProcessPool
-            if work_item is not None:
-                work_item.future.set_exception(raised_error)
-                del work_item
-            with self.shutdown_lock:
-                self.thread_wakeup.wakeup()
-        else:
-            super()._on_queue_feeder_error(e, obj)
+        except BaseException as hook_exc:
+            # An error here would kill the feeder thread silently and leave
+            # every later task unsent: flag the executor as broken instead
+            raised_error = BrokenProcessPool(
+                "The call queue feeder thread crashed: the executor is "
+                "broken and the pending tasks have been cancelled."
+            )
+            tb = traceback.format_exception(
+                type(hook_exc), hook_exc, hook_exc.__traceback__
+            )
+            raised_error.__cause__ = _RemoteTraceback("".join(tb))
+            LOGGER.critical(
+                "Exception in call queue feeder error hook:", exc_info=True
+            )
+            self.executor_flags.flag_as_broken(raised_error)
+        if work_item is not None:
+            work_item.future.set_exception(raised_error)
+            del work_item
+        with self.shutdown_lock:
+            self.thread_wakeup.wakeup()
 
 
 def _get_chunks(chunksize, *iterables):
@@ -622,9 +640,10 @@ class _ExecutorManagerThread(threading.Thread):
             # Nothing in the loop is expected to raise, so this is a bug or a
             # failure of the runtime itself, such as a queue that cannot
             # start its feeder thread while the interpreter is shutting down
-            # (gh-109047). Letting the exception kill this thread would leave
-            # every pending future unresolved and the executor looking
-            # healthy, so a caller waiting on a result would hang forever.
+            # (python/cpython#109047). Letting the exception kill this thread
+            # would leave every pending future unresolved and the executor
+            # looking healthy, so a caller waiting on a result would hang
+            # forever.
             # Flag the executor as broken instead, with the error as cause.
             bpe = BrokenProcessPool(
                 "The executor manager thread crashed: the executor is broken "
@@ -644,6 +663,10 @@ class _ExecutorManagerThread(threading.Thread):
 
             result_item, is_broken, bpe = self.wait_result_broken_or_wakeup()
 
+            # The call queue feeder thread flags the executor broken and
+            # wakes us up when it cannot report a task failure itself
+            if not is_broken and self.executor_flags.broken is not None:
+                is_broken, bpe = True, self.executor_flags.broken
             if is_broken:
                 self.terminate_broken(bpe)
                 return
@@ -1212,6 +1235,7 @@ class ProcessPoolExecutor(Executor):
             running_work_items=self._running_work_items,
             thread_wakeup=self._executor_manager_thread_wakeup,
             shutdown_lock=self._shutdown_lock,
+            executor_flags=self._flags,
             reducers=job_reducers,
             ctx=self._context,
         )

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -1306,6 +1306,29 @@ class ExecutorTest:
         with pytest.raises(BrokenProcessPool):
             self.executor.submit(int)
 
+    @pytest.mark.broken_pool
+    def test_feeder_error_hook_crash_breaks_executor(self):
+        """A failure in the call queue's feeder error hook breaks the
+        executor rather than leaving the submitted futures pending forever."""
+        self.executor.submit(int).result()  # starts the feeder thread
+        manager = self.executor._executor_manager_thread
+
+        # Make the hook itself fail when it handles the pickling error, as
+        # when the manager thread already dropped the work id: the ``remove``
+        # of the id from this list then raises ValueError
+        self.executor._call_queue.running_work_items = []
+        with pytest.raises(
+            BrokenProcessPool, match="feeder thread crashed"
+        ) as exc_info:
+            self.executor.submit(id, ErrorAtPickle()).result(
+                timeout=_executor_mixin.TIMEOUT
+            )
+        assert "ValueError" in str(exc_info.value.__cause__)
+        manager.join(_executor_mixin.TIMEOUT)
+        assert not manager.is_alive()
+        with pytest.raises(BrokenProcessPool):
+            self.executor.submit(int)
+
 
 def _custom_initializer():
     """_custom_initializer is module function to be picklable

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -29,6 +29,7 @@ from concurrent.futures._base import (
 import loky
 from loky.process_executor import (
     LokyRecursionError,
+    BrokenProcessPool,
     ShutdownExecutorError,
     TerminatedWorkerError,
 )
@@ -1281,6 +1282,29 @@ class ExecutorTest:
             assert len(w) == 0, [w.message for w in w]
         finally:
             _end_spawned_pthread()
+
+    @pytest.mark.broken_pool
+    def test_manager_thread_crash_breaks_executor(self):
+        """An unexpected error in the manager thread breaks the executor
+        rather than leaving the submitted futures pending forever."""
+        self.executor.submit(int).result()  # starts the manager thread
+        manager = self.executor._executor_manager_thread
+
+        def crash():
+            raise RuntimeError("manager thread bug")
+
+        # The manager thread may crash before or after the submit below
+        # depending on scheduling: both paths raise the same exception.
+        manager.wait_result_broken_or_wakeup = crash
+        with pytest.raises(
+            BrokenProcessPool, match="manager thread crashed"
+        ) as exc_info:
+            self.executor.submit(int).result(timeout=_executor_mixin.TIMEOUT)
+        assert "manager thread bug" in str(exc_info.value.__cause__)
+        manager.join(_executor_mixin.TIMEOUT)
+        assert not manager.is_alive()
+        with pytest.raises(BrokenProcessPool):
+            self.executor.submit(int)
 
 
 def _custom_initializer():


### PR DESCRIPTION
I hit a crash in [MNE-Python CIs](https://github.com/mne-tools/mne-python/actions/runs/34660125563/job/103460705362?pr=14302#step:24:11449) and used Claude to investigate it. During `test_apply_function_evk_ch_access`, loky's executor manager thread died silently, so `joblib` waited forever on futures that would never resolve. The test only ended because `pytest-timeout` killed the process, which showed up as the `gw1` worker crash, and the original exception (whatever it was!) was lost with it.

With these changes, 1) a crash in the manager thread is logged via `LOGGER.critical` with the full traceback, 2) the executor is flagged broken and its workers killed, and 3) every pending future gets a BrokenProcessPool whose cause carries that traceback. `joblib` re-raises it in the test, which fails immediately with a useful traceback rather than hanging, and the subsequent `abort_everything` now completes cleanly instead of dying with a `KeyError` and leaking the executor's queues and processes. 😅 

I investigated and implemented these changes this with Claude Opus 5 and Fable 5 so take with a grain of salt. But the reasoning and code all look reasonable to me. I can't reliably reproduce the MNE failure locally, but the test added here fails similar to MNE's -- raises a `TimeoutError`, then hangs at test exit -- so the mechanism seems likely well captured by the test, and is fixed by the changes.

I also had Claude look for other instances of "a waiter that depends on a thread or process which can die without notifying it", and it found the same pattern in `QueueFeederThread`, which led to a second test (true TDD!) and second sibling fix here. That's the second commit.